### PR TITLE
test(team): test(team): 팀 수정 로직(Service/Entity) 및 VO 단위 테스트 추가

### DIFF
--- a/src/main/java/com/shootdoori/match/team/domain/Team.java
+++ b/src/main/java/com/shootdoori/match/team/domain/Team.java
@@ -81,8 +81,9 @@ public class Team {
         return timeStamp.getCreatedAt();
     }
 
-    public void changeTeamInfo(String name, String university, String description) {
+    public void changeTeamInfo(String name, String teamType, String university, String description) {
         this.teamName = TeamName.of(name);
+        this.teamType = TeamType.fromDisplayName(teamType);
         this.universityName = UniversityName.of(university);
         this.description = Description.of(description);
     }

--- a/src/main/java/com/shootdoori/match/team/domain/Team.java
+++ b/src/main/java/com/shootdoori/match/team/domain/Team.java
@@ -81,7 +81,7 @@ public class Team {
         return timeStamp.getCreatedAt();
     }
 
-    public void changeTeamInfo(String name, String university, String description, Long userId) {
+    public void changeTeamInfo(String name, String university, String description) {
         this.teamName = TeamName.of(name);
         this.universityName = UniversityName.of(university);
         this.description = Description.of(description);

--- a/src/main/java/com/shootdoori/match/team/dto/TeamRequestDto.java
+++ b/src/main/java/com/shootdoori/match/team/dto/TeamRequestDto.java
@@ -4,7 +4,6 @@ public record TeamRequestDto(
     String name,
     String description,
     String university,
-    String skillLevel,
     String teamType
 ) {
 

--- a/src/main/java/com/shootdoori/match/team/service/TeamCommandService.java
+++ b/src/main/java/com/shootdoori/match/team/service/TeamCommandService.java
@@ -18,7 +18,8 @@ public class TeamCommandService {
     private final TeamRepository teamRepository;
     private final TeamMapper teamMapper;
 
-    public TeamCommandService(TeamQueryService teamQueryService, TeamMemberQueryService teamMemberQueryService, TeamRepository teamRepository,
+    public TeamCommandService(TeamQueryService teamQueryService,
+        TeamMemberQueryService teamMemberQueryService, TeamRepository teamRepository,
         TeamMapper teamMapper) {
         this.teamQueryService = teamQueryService;
         this.teamMemberQueryService = teamMemberQueryService;
@@ -37,7 +38,8 @@ public class TeamCommandService {
 
         Team team = teamQueryService.findByIdForEntity(id);
 
-        team.changeTeamInfo(requestDto.name(), requestDto.university(), requestDto.description());
+        team.changeTeamInfo(requestDto.name(), requestDto.teamType(), requestDto.university(),
+            requestDto.description());
 
         return teamMapper.toTeamDetailResponse(team);
     }

--- a/src/main/java/com/shootdoori/match/team/service/TeamCommandService.java
+++ b/src/main/java/com/shootdoori/match/team/service/TeamCommandService.java
@@ -37,8 +37,7 @@ public class TeamCommandService {
 
         Team team = teamQueryService.findByIdForEntity(id);
 
-        team.changeTeamInfo(requestDto.name(), requestDto.university(), requestDto.description(),
-            userId);
+        team.changeTeamInfo(requestDto.name(), requestDto.university(), requestDto.description());
 
         return teamMapper.toTeamDetailResponse(team);
     }

--- a/src/test/java/com/shootdoori/match/team/domain/TeamTest.java
+++ b/src/test/java/com/shootdoori/match/team/domain/TeamTest.java
@@ -1,0 +1,34 @@
+package com.shootdoori.match.team.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TeamTest {
+
+    private Team team;
+
+    @BeforeEach
+    void setUp() {
+        team = Team.of("감자빵 FC", "강원대학교", TeamType.CENTRAL_CLUB, "주 2회 축구합니다.");
+    }
+
+    @Test
+    @DisplayName("팀 정보 수정 테스트")
+    void changeTeamInfo() {
+        // given
+        String newName = "닭갈비 FC";
+        String newUniversity = "강원대학교";
+        String newDescription = "변경된 설명란";
+
+        // when
+        team.changeTeamInfo(newName, newUniversity, newDescription);
+
+        // then
+        assertThat(team.getTeamName().teamName()).isEqualTo(newName);
+        assertThat(team.getUniversityName().universityName()).isEqualTo(newUniversity);
+        assertThat(team.getDescription().description()).isEqualTo(newDescription);
+    }
+}

--- a/src/test/java/com/shootdoori/match/team/domain/TeamTest.java
+++ b/src/test/java/com/shootdoori/match/team/domain/TeamTest.java
@@ -20,14 +20,16 @@ class TeamTest {
     void changeTeamInfo() {
         // given
         String newName = "닭갈비 FC";
+        String newTeamType = "과동아리";
         String newUniversity = "강원대학교";
         String newDescription = "변경된 설명란";
 
         // when
-        team.changeTeamInfo(newName, newUniversity, newDescription);
+        team.changeTeamInfo(newName, newTeamType, newUniversity, newDescription);
 
         // then
         assertThat(team.getTeamName().teamName()).isEqualTo(newName);
+        assertThat(team.getTeamType().getDisplayName()).isEqualTo(newTeamType);
         assertThat(team.getUniversityName().universityName()).isEqualTo(newUniversity);
         assertThat(team.getDescription().description()).isEqualTo(newDescription);
     }

--- a/src/test/java/com/shootdoori/match/team/domain/TeamTypeTest.java
+++ b/src/test/java/com/shootdoori/match/team/domain/TeamTypeTest.java
@@ -1,0 +1,38 @@
+package com.shootdoori.match.team.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class TeamTypeTest {
+
+    @ParameterizedTest
+    @DisplayName("displayName 테스트")
+    @CsvSource({
+        "중앙동아리, CENTRAL_CLUB",
+        "과동아리, DEPARTMENT_CLUB",
+        "기타, OTHER"
+    })
+    void fromDisplayName(String displayName, TeamType expected) {
+        // when
+        TeamType actual = TeamType.fromDisplayName(displayName);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("displayName 예외 테스트")
+    void fromDisplayName_throwsException() {
+        // given
+        String wrongDisplayName = "예외가 펑";
+
+        // when & then
+        assertThatThrownBy(() -> TeamType.fromDisplayName(wrongDisplayName))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/shootdoori/match/team/domain/value/DescriptionTest.java
+++ b/src/test/java/com/shootdoori/match/team/domain/value/DescriptionTest.java
@@ -1,0 +1,61 @@
+package com.shootdoori.match.team.domain.value;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Description VO 테스트")
+class DescriptionTest {
+
+    @Test
+    @DisplayName("정상적인 설명 생성 테스트 (1000자 이하)")
+    void of_Success() {
+        // given
+        String validDescription = "이것은 정상적인 설명입니다.";
+        
+        // when
+        Description description = Description.of(validDescription);
+        
+        // then
+        assertThat(description.description()).isEqualTo(validDescription);
+    }
+    
+    @Test
+    @DisplayName("설명이 1000자를 초과하면 예외 발생")
+    void of_Fail_MaxLengthExceeded() {
+        // given
+        String longDescription = "a".repeat(1001);
+        
+        // when & then
+        assertThatThrownBy(() -> Description.of(longDescription))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+    
+    @Test
+    @DisplayName("설명이 null이면 null로 저장된다")
+    void of_Null() {
+        // given
+        String nullDescription = null;
+        
+        // when
+        Description description = Description.of(nullDescription);
+        
+        // then
+        assertThat(description.description()).isEqualTo(null);
+    }
+
+    @Test
+    @DisplayName("설명이 빈 문자열이거나 공백이면 null로 저장된다")
+    void of_Blank_To_Null() {
+        // given
+        String blankDescription = "   ";
+
+        // when
+        Description description = Description.of(blankDescription);
+
+        // then
+        assertThat(description.description()).isEqualTo(null);
+    }
+}

--- a/src/test/java/com/shootdoori/match/team/domain/value/TeamNameTest.java
+++ b/src/test/java/com/shootdoori/match/team/domain/value/TeamNameTest.java
@@ -1,0 +1,58 @@
+package com.shootdoori.match.team.domain.value;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.shootdoori.match.exception.domain.team.TeamNameException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("TeamName VO 테스트")
+class TeamNameTest {
+
+    @Test
+    @DisplayName("정상적인 팀 이름 생성 테스트")
+    void of_Success() {
+        // given
+        String validName = "정상적인 팀이름";
+
+        // when
+        TeamName teamName = TeamName.of(validName);
+
+        // then
+        assertThat(teamName.teamName()).isEqualTo(validName);
+    }
+
+    @Test
+    @DisplayName("팀 이름이 100자를 초과하면 예외 발생")
+    void of_Fail_MaxLengthExceeded() {
+        // given
+        String longName = "a".repeat(101);
+
+        // when & then
+        assertThatThrownBy(() -> TeamName.of(longName))
+            .isInstanceOf(TeamNameException.class);
+    }
+
+    @Test
+    @DisplayName("팀 이름이 null이면 예외 발생")
+    void of_Fail_Null() {
+        // given
+        String nullName = null;
+
+        // when & then
+        assertThatThrownBy(() -> TeamName.of(nullName))
+            .isInstanceOf(TeamNameException.class);
+    }
+
+    @Test
+    @DisplayName("팀 이름이 빈 문자열이거나 공백이면 예외 발생")
+    void of_Fail_Blank() {
+        // given
+        String blankName = "   ";
+
+        // when & then
+        assertThatThrownBy(() -> TeamName.of(blankName))
+            .isInstanceOf(TeamNameException.class);
+    }
+}

--- a/src/test/java/com/shootdoori/match/team/domain/value/UniversityNameTest.java
+++ b/src/test/java/com/shootdoori/match/team/domain/value/UniversityNameTest.java
@@ -1,0 +1,36 @@
+package com.shootdoori.match.team.domain.value;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("UniversityName VO 테스트")
+class UniversityNameTest {
+
+    @Test
+    @DisplayName("정상적인 대학교 이름 생성 테스트")
+    void of_Success() {
+        // given
+        String validName = "강원대학교";
+
+        // when
+        UniversityName universityName = UniversityName.of(validName);
+
+        // then
+        assertThat(universityName.universityName()).isEqualTo(validName);
+    }
+
+    @Test
+    @DisplayName("대학교 이름이 100자를 초과하면 예외 발생")
+    void of_Fail_MaxLengthExceeded() {
+        // given
+        String longName = "a".repeat(101);
+
+        // when & then
+        assertThatThrownBy(() -> UniversityName.of(longName))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}
+

--- a/src/test/java/com/shootdoori/match/team/service/TeamCommandServiceTest.java
+++ b/src/test/java/com/shootdoori/match/team/service/TeamCommandServiceTest.java
@@ -1,12 +1,10 @@
 package com.shootdoori.match.team.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import com.shootdoori.match.team.domain.Team;
 import com.shootdoori.match.team.domain.TeamType;
-import com.shootdoori.match.team.dto.CreateTeamResponseDto;
 import com.shootdoori.match.team.dto.TeamDetailResponseDto;
 import com.shootdoori.match.team.dto.TeamRequestDto;
 import com.shootdoori.match.team.mapper.TeamMapper;

--- a/src/test/java/com/shootdoori/match/team/service/TeamCommandServiceTest.java
+++ b/src/test/java/com/shootdoori/match/team/service/TeamCommandServiceTest.java
@@ -1,0 +1,64 @@
+package com.shootdoori.match.team.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.shootdoori.match.team.domain.Team;
+import com.shootdoori.match.team.domain.TeamType;
+import com.shootdoori.match.team.dto.CreateTeamResponseDto;
+import com.shootdoori.match.team.dto.TeamDetailResponseDto;
+import com.shootdoori.match.team.dto.TeamRequestDto;
+import com.shootdoori.match.team.mapper.TeamMapper;
+import com.shootdoori.match.team.repository.TeamRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TeamCommandService 테스트")
+class TeamCommandServiceTest {
+
+    @Mock
+    private TeamQueryService teamQueryService;
+    @Mock
+    private TeamMemberQueryService teamMemberQueryService;
+    @Mock
+    private TeamRepository teamRepository;
+    @Mock
+    private TeamMapper teamMapper;
+
+    private TeamCommandService teamCommandService;
+
+    @BeforeEach
+    void setUp() {
+        teamCommandService = new TeamCommandService(teamQueryService, teamMemberQueryService,
+            teamRepository, teamMapper);
+    }
+
+    @Test
+    @DisplayName("팀 정보 수정 성공 테스트")
+    void update() {
+        // given
+        Long teamId = 1L;
+        Long userId = 1L;
+        TeamRequestDto requestDto = new TeamRequestDto("수정된이름", "수정된설명", "수정된대학", "과동아리");
+
+        Team team = Team.of("원래이름", "원래대학", TeamType.CENTRAL_CLUB, "원래설명");
+        TeamDetailResponseDto expectedResponse = new TeamDetailResponseDto(teamId, "수정된이름", "수정된설명", "수정된대학", "과동아리", "20251121");
+
+        given(teamQueryService.findByIdForEntity(teamId)).willReturn(team);
+        given(teamMapper.toTeamDetailResponse(team)).willReturn(expectedResponse);
+
+        // when
+        teamCommandService.update(teamId, requestDto, userId);
+
+        // then
+        assertThat(team.getTeamName().teamName()).isEqualTo("수정된이름");
+        assertThat(team.getUniversityName().universityName()).isEqualTo("수정된대학");
+        assertThat(team.getDescription().description()).isEqualTo("수정된설명");
+    }
+}


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
#10 

---

## 🛠️ 뭘 했는지

- team 도메인 `changeTeamInfo` 테스트 추가
- TeamCommandService `update` 테스트 추가
- VO 테스트 추가
  - Description 테스트
  - TeamName 테스트
  - UniversityName 테스트

---

## 📷 스크린샷
❌ 

---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
- 서비스 단위 테스트 코드의 방향성이 조금 어려운 것 같습니다. 부가 설명을 좀 더 해주실 수 있을까요?
단순히 DB를 꺼내 쓰는 부분에 대해서는 이번에 테스트 코드를 작성하지 않았습니다. (create, 조회 메서드 등)

---

*PR 확인 부탁드려요! 🙏*