### PR TITLE
test(join-waiting): JoinWaiting 도메인 및 CommandService 단위 테스트 작성

### DIFF
--- a/src/main/java/com/shootdoori/match/joinWaiting/domain/JoinWaiting.java
+++ b/src/main/java/com/shootdoori/match/joinWaiting/domain/JoinWaiting.java
@@ -1,7 +1,6 @@
 package com.shootdoori.match.joinWaiting.domain;
 
 import com.shootdoori.match.entity.common.TimeStamp;
-import com.shootdoori.match.exception.common.ErrorCode;
 import com.shootdoori.match.exception.common.NoPermissionException;
 import com.shootdoori.match.exception.domain.joinwaiting.JoinWaitingNotPendingException;
 import jakarta.persistence.Column;

--- a/src/test/java/com/shootdoori/match/joinWaiting/domain/JoinWaitingStatusTest.java
+++ b/src/test/java/com/shootdoori/match/joinWaiting/domain/JoinWaitingStatusTest.java
@@ -1,0 +1,40 @@
+package com.shootdoori.match.joinWaiting.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class JoinWaitingStatusTest {
+
+    @ParameterizedTest
+    @DisplayName("displayName 테스트")
+    @CsvSource({
+        "대기중, PENDING",
+        "승인됨, APPROVED",
+        "거절됨, REJECTED",
+        "취소됨, CANCELED"
+    })
+    void fromDisplayName(String displayName, JoinWaitingStatus expected) {
+        // when
+        JoinWaitingStatus actual = JoinWaitingStatus.fromDisplayName(displayName);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("displayName 예외 테스트")
+    void fromDisplayName_throwsException() {
+        // given
+        String wrongDisplayName = "예외가 펑";
+
+        // when & then
+        assertThatThrownBy(() -> JoinWaitingStatus.fromDisplayName(wrongDisplayName))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/shootdoori/match/joinWaiting/domain/JoinWaitingTest.java
+++ b/src/test/java/com/shootdoori/match/joinWaiting/domain/JoinWaitingTest.java
@@ -1,0 +1,104 @@
+package com.shootdoori.match.joinWaiting.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.shootdoori.match.exception.common.NoPermissionException;
+import com.shootdoori.match.exception.domain.joinwaiting.JoinWaitingNotPendingException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class JoinWaitingTest {
+
+    private JoinWaiting joinWaiting;
+
+    @BeforeEach
+    void setUp() {
+        joinWaiting = JoinWaiting.of(1L, 1L, "열심히 하겠습니다!", JoinWaitingType.MEMBER);
+    }
+
+    @Test
+    @DisplayName("가입 대기 승인")
+    void approve() {
+        // when
+        joinWaiting.approve(1L, "환영합니다!");
+
+        // then
+        assertThat(joinWaiting.getStatus()).isEqualTo(JoinWaitingStatus.APPROVED);
+    }
+
+    @Test
+    @DisplayName("가입 대기 거절")
+    void reject() {
+        // when
+        joinWaiting.reject(1L, "죄송합니다!");
+
+        // then
+        assertThat(joinWaiting.getStatus()).isEqualTo(JoinWaitingStatus.REJECTED);
+    }
+
+    @Test
+    @DisplayName("가입 대기 취소")
+    void cancel() {
+        // when
+        joinWaiting.cancel(1L, "개인 사정으로 취소합니다.");
+
+        // then
+        assertThat(joinWaiting.getStatus()).isEqualTo(JoinWaitingStatus.CANCELED);
+    }
+
+    @Test
+    @DisplayName("신청자 검증 성공")
+    void validateApplicant() {
+        // given
+        Long applicantId = 1L;
+
+        // when & then
+        joinWaiting.validateApplicant(applicantId);
+    }
+
+    @Test
+    @DisplayName("대기 상태가 아닐 때 승인하면 예외 발생")
+    void approve_fail_not_pending() {
+        // given
+        joinWaiting.approve(1L, "이미 승인됨");
+
+        // when & then
+        assertThatThrownBy(() -> joinWaiting.approve(1L, "승인 안됨"))
+            .isInstanceOf(JoinWaitingNotPendingException.class);
+    }
+
+    @Test
+    @DisplayName("대기 상태가 아닐 때 거절하면 예외 발생")
+    void reject_fail_not_pending() {
+        // given
+        joinWaiting.approve(1L, "이미 승인됨");
+
+        // when & then
+        assertThatThrownBy(() -> joinWaiting.reject(1L, "거절 안됨"))
+            .isInstanceOf(JoinWaitingNotPendingException.class);
+    }
+
+    @Test
+    @DisplayName("대기 상태가 아닐 때 취소하면 예외 발생")
+    void cancel_fail_not_pending() {
+        // given
+        joinWaiting.approve(1L, "이미 승인됨");
+
+        // when & then
+        assertThatThrownBy(() -> joinWaiting.cancel(1L, "취소 안됨"))
+            .isInstanceOf(JoinWaitingNotPendingException.class);
+    }
+
+    @Test
+    @DisplayName("신청자 본인이 아니면 예외 발생")
+    void validateApplicant_fail() {
+        // given
+        Long otherUserId = 999L;
+
+        // when & then
+        assertThatThrownBy(() -> joinWaiting.validateApplicant(otherUserId))
+            .isInstanceOf(NoPermissionException.class);
+    }
+}

--- a/src/test/java/com/shootdoori/match/joinWaiting/domain/JoinWaitingTypeTest.java
+++ b/src/test/java/com/shootdoori/match/joinWaiting/domain/JoinWaitingTypeTest.java
@@ -1,0 +1,38 @@
+package com.shootdoori.match.joinWaiting.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class JoinWaitingTypeTest {
+
+    @ParameterizedTest
+    @DisplayName("displayName 테스트")
+    @CsvSource({
+        "팀원, MEMBER",
+        "용병, MERCENARY"
+    })
+    void fromDisplayName(String displayName, JoinWaitingType expected) {
+        // when
+        JoinWaitingType actual = JoinWaitingType.fromDisplayName(displayName);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("displayName 예외 테스트")
+    void fromDisplayName_throwsException() {
+        // given
+        String wrongDisplayName = "예외가 펑";
+
+        // when & then
+        assertThatThrownBy(() -> JoinWaitingType.fromDisplayName(wrongDisplayName))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/shootdoori/match/joinWaiting/service/JoinWaitingCommandServiceTest.java
+++ b/src/test/java/com/shootdoori/match/joinWaiting/service/JoinWaitingCommandServiceTest.java
@@ -1,0 +1,161 @@
+package com.shootdoori.match.joinWaiting.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.shootdoori.match.exception.common.NoPermissionException;
+import com.shootdoori.match.joinWaiting.domain.JoinWaiting;
+import com.shootdoori.match.joinWaiting.domain.JoinWaitingStatus;
+import com.shootdoori.match.joinWaiting.domain.JoinWaitingType;
+import com.shootdoori.match.joinWaiting.dto.JoinWaitingApproveRequestDto;
+import com.shootdoori.match.joinWaiting.dto.JoinWaitingCancelRequestDto;
+import com.shootdoori.match.joinWaiting.dto.JoinWaitingRejectRequestDto;
+import com.shootdoori.match.joinWaiting.mapper.JoinWaitingMapper;
+import com.shootdoori.match.joinWaiting.repository.JoinWaitingRepository;
+import com.shootdoori.match.team.service.TeamMemberQueryService;
+import com.shootdoori.match.team.service.TeamQueryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class JoinWaitingCommandServiceTest {
+
+    @Mock
+    private TeamQueryService teamQueryService;
+
+    @Mock
+    private TeamMemberQueryService teamMemberQueryService;
+
+    @Mock
+    private JoinWaitingQueryService joinWaitingQueryService;
+
+    @Mock
+    private JoinWaitingRepository joinWaitingRepository;
+
+    @Mock
+    private JoinWaitingMapper joinWaitingMapper;
+
+    private JoinWaitingCommandService joinWaitingCommandService;
+
+    private final Long teamId = 1L;
+    private final Long joinWaitingId = 1L;
+    private final Long loginUserId = 1L;
+    private final Long applicantId = 2L;
+
+    @BeforeEach
+    void setUp() {
+        joinWaitingCommandService = new JoinWaitingCommandService(teamQueryService,
+            teamMemberQueryService, joinWaitingQueryService, joinWaitingRepository,
+            joinWaitingMapper);
+    }
+
+    @Test
+    @DisplayName("가입 대기 승인 성공")
+    void approve() {
+        // given
+        JoinWaitingApproveRequestDto requestDto = new JoinWaitingApproveRequestDto("일반멤버", "맘에 듭니다.");
+        JoinWaiting joinWaiting = JoinWaiting.of(teamId, applicantId, "가입신청", JoinWaitingType.MEMBER);
+
+        given(joinWaitingQueryService.findByIdForEntity(joinWaitingId)).willReturn(joinWaiting);
+
+        // when
+        joinWaitingCommandService.approve(teamId, joinWaitingId, loginUserId, requestDto);
+
+        // then
+        assertThat(joinWaiting.getStatus()).isEqualTo(JoinWaitingStatus.APPROVED);
+        verify(teamMemberQueryService, times(1)).validateLeaderOrViceLeader(teamId, loginUserId);
+    }
+
+    @Test
+    @DisplayName("가입 대기 거절 성공")
+    void reject() {
+        // given
+        JoinWaitingRejectRequestDto requestDto = new JoinWaitingRejectRequestDto("죄송합니다.");
+        JoinWaiting joinWaiting = JoinWaiting.of(teamId, applicantId, "가입신청", JoinWaitingType.MEMBER);
+
+        given(joinWaitingQueryService.findByIdForEntity(joinWaitingId)).willReturn(joinWaiting);
+
+        // when
+        joinWaitingCommandService.reject(teamId, joinWaitingId, loginUserId, requestDto);
+
+        // then
+        assertThat(joinWaiting.getStatus()).isEqualTo(JoinWaitingStatus.REJECTED);
+        verify(teamMemberQueryService, times(1)).validateLeaderOrViceLeader(teamId, loginUserId);
+    }
+
+    @Test
+    @DisplayName("가입 대기 취소 성공")
+    void cancel() {
+        // given
+        JoinWaitingCancelRequestDto requestDto = new JoinWaitingCancelRequestDto("개인 사정으로 취소합니다.");
+        JoinWaiting joinWaiting = JoinWaiting.of(teamId, applicantId, "가입신청", JoinWaitingType.MEMBER);
+
+        given(joinWaitingQueryService.findByIdForEntity(joinWaitingId)).willReturn(joinWaiting);
+
+        // when
+        joinWaitingCommandService.cancel(teamId, joinWaitingId, applicantId, requestDto);
+
+        // then
+        assertThat(joinWaiting.getStatus()).isEqualTo(JoinWaitingStatus.CANCELED);
+    }
+
+    @Test
+    @DisplayName("권한이 없는 사용자가 승인하면 예외 발생")
+    void approve_fail_no_permission() {
+        // given
+        Long unauthorizedUserId = 999L;
+        JoinWaitingApproveRequestDto requestDto = new JoinWaitingApproveRequestDto("일반멤버", "맘에 듭니다.");
+        JoinWaiting joinWaiting = JoinWaiting.of(teamId, applicantId, "가입신청", JoinWaitingType.MEMBER);
+
+        given(joinWaitingQueryService.findByIdForEntity(joinWaitingId)).willReturn(joinWaiting);
+        doThrow(new NoPermissionException()).when(teamMemberQueryService)
+            .validateLeaderOrViceLeader(teamId, unauthorizedUserId);
+
+        // when & then
+        assertThatThrownBy(
+            () -> joinWaitingCommandService.approve(teamId, joinWaitingId, unauthorizedUserId, requestDto))
+            .isInstanceOf(NoPermissionException.class);
+    }
+
+    @Test
+    @DisplayName("권한이 없는 사용자가 거절하면 예외 발생")
+    void reject_fail_no_permission() {
+        // given
+        Long unauthorizedUserId = 999L;
+        JoinWaitingRejectRequestDto requestDto = new JoinWaitingRejectRequestDto("맘에 듭니다.");
+        JoinWaiting joinWaiting = JoinWaiting.of(teamId, applicantId, "가입신청", JoinWaitingType.MEMBER);
+
+        given(joinWaitingQueryService.findByIdForEntity(joinWaitingId)).willReturn(joinWaiting);
+        doThrow(new NoPermissionException())
+            .when(teamMemberQueryService).validateLeaderOrViceLeader(teamId, unauthorizedUserId);
+
+        // when & then
+        assertThatThrownBy(
+            () -> joinWaitingCommandService.reject(teamId, joinWaitingId, unauthorizedUserId, requestDto))
+            .isInstanceOf(NoPermissionException.class);
+    }
+
+    @Test
+    @DisplayName("가입 요청 당사자가 아닌 유저가 취소하면 예외 발생")
+    void cancel_fail_no_permission() {
+        // given
+        Long otherUserId = 999L;
+        JoinWaitingCancelRequestDto requestDto = new JoinWaitingCancelRequestDto("개인 사정으로 취소합니다.");
+        JoinWaiting joinWaiting = JoinWaiting.of(teamId, applicantId, "가입신청", JoinWaitingType.MEMBER);
+
+        given(joinWaitingQueryService.findByIdForEntity(joinWaitingId)).willReturn(joinWaiting);
+
+        // when & then
+        assertThatThrownBy(
+            () -> joinWaitingCommandService.cancel(teamId, joinWaitingId, otherUserId, requestDto))
+            .isInstanceOf(NoPermissionException.class);
+    }
+}


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
Closes #19 

---

## 🛠️ 뭘 했는지
- JoinWaitingStatus 단위 테스트 구현
- JoinWaitingType 단위 테스트 구현
- JoinWaiting entity 단위 테스트 구현
- JoinWaitingCommandService 단위 테스트 구현

---

## 📷 스크린샷
❌ 

---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
 - JoinWaitingCommandService에서 반환값인 ResponseDTO를 검증하는 것보다, 핵심 비즈니스 로직인 `Entity의 Status 변경 여부`를 직접 검증하는 것이 더 중요하다고 판단했습니다. 적절한 방향이라고 생각하시는지 궁금합니다.

---

*PR 확인 부탁드려요! 🙏*