### PR TITLE
feat: refresh token 재발급 API 구현 & 단위 테스트 작성

### DIFF
--- a/src/main/java/com/shootdoori/match/exception/common/ErrorCode.java
+++ b/src/main/java/com/shootdoori/match/exception/common/ErrorCode.java
@@ -77,6 +77,7 @@ public enum ErrorCode {
     FAIL_REGISTER("회원가입에 실패하였습니다.", HttpStatus.BAD_REQUEST),
     FAIL_LOGIN("잘못된 이메일 또는 비밀번호입니다.", HttpStatus.BAD_REQUEST),
     INVALID_AUTH_INFO("인증 정보가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
+    STOLEN_TOKEN_DETECTED("토큰 탈취가 감지되었습니다.", HttpStatus.UNAUTHORIZED),
 
     // Review
     MATCH_NOT_FINISHED_YET("아직 경기가 종료되지 않아 리뷰를 작성할 수 없습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/shootdoori/match/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/shootdoori/match/exception/handler/GlobalExceptionHandler.java
@@ -6,6 +6,8 @@ import com.shootdoori.match.exception.common.UnauthorizedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -64,6 +66,16 @@ public class GlobalExceptionHandler {
         log.error("[GlobalExceptionHandler] Unexpected Exception occurred", e);
         ErrorResponse response = new ErrorResponse("INTERNAL_SERVER_ERROR", "Unexpected server error occurred.");
         return ResponseEntity.internalServerError().body(response);
+    }
+
+    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+    public ResponseEntity<ErrorResponse> handleOptimisticLockingFailureException(ObjectOptimisticLockingFailureException e) {
+        log.warn("[GlobalExceptionHandler] Optimistic locking failure: {}", e.getMessage());
+
+        ErrorCode errorCode = ErrorCode.INVALID_TOKEN;
+        return ResponseEntity
+            .status(errorCode.getHttpStatus())
+            .body(ErrorResponse.of(errorCode, "동시 요청이 감지되었습니다. 다시 로그인해주세요."));
     }
 
     public static class ErrorResponse {

--- a/src/main/java/com/shootdoori/match/user/controller/LoginController.java
+++ b/src/main/java/com/shootdoori/match/user/controller/LoginController.java
@@ -1,17 +1,16 @@
 package com.shootdoori.match.user.controller;
 
 import com.shootdoori.match.dto.LoginRequest;
-import com.shootdoori.match.dto.TokenRefreshRequest;
+import com.shootdoori.match.resolver.LoginUser;
 import com.shootdoori.match.user.dto.AuthTokenResponse;
+import com.shootdoori.match.user.dto.TokenRefreshRequest;
 import com.shootdoori.match.user.dto.UserCreateRequest;
 import com.shootdoori.match.user.service.AuthService;
+import com.shootdoori.match.user.service.TokenRefreshService;
 import com.shootdoori.match.user.service.UserCommandService;
-import com.shootdoori.match.resolver.LoginUser;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,13 +23,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auth")
 public class LoginController {
 
-    private static final Logger logger = LoggerFactory.getLogger(LoginController.class);
     private final AuthService authService;
     private final UserCommandService userCommandService;
+    private final TokenRefreshService tokenRefreshService;
 
-    public LoginController(AuthService authService, UserCommandService userCommandService) {
+    public LoginController(AuthService authService, UserCommandService userCommandService,
+        TokenRefreshService tokenRefreshService) {
         this.authService = authService;
         this.userCommandService = userCommandService;
+        this.tokenRefreshService = tokenRefreshService;
     }
 
     @PostMapping("/login")
@@ -58,9 +59,9 @@ public class LoginController {
 
     @PostMapping("/refresh")
     public ResponseEntity<AuthTokenResponse> refresh(
-        @RequestBody TokenRefreshRequest token
+        @RequestBody TokenRefreshRequest request
     ) {
-        return null;
+        return new ResponseEntity<>(tokenRefreshService.refresh(request), HttpStatus.OK);
     }
 
     @PostMapping("/logout")
@@ -92,5 +93,4 @@ public class LoginController {
     ) {
         return null;
     }
-
 }

--- a/src/main/java/com/shootdoori/match/user/domain/ClientInfo.java
+++ b/src/main/java/com/shootdoori/match/user/domain/ClientInfo.java
@@ -1,0 +1,12 @@
+package com.shootdoori.match.user.domain;
+
+public class ClientInfo {
+
+    private final String userAgent;
+    private final DeviceType deviceType;
+
+    public ClientInfo(String userAgent, DeviceType deviceType) {
+        this.userAgent = userAgent;
+        this.deviceType = deviceType;
+    }
+}

--- a/src/main/java/com/shootdoori/match/user/domain/RefreshToken.java
+++ b/src/main/java/com/shootdoori/match/user/domain/RefreshToken.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 
 @Entity
@@ -29,7 +30,13 @@ public class RefreshToken {
     String userAgent;
 
     @Column
+    boolean revoked = false;
+
+    @Column
     LocalDateTime expiryDate;
+
+    @Version
+    private Long version;
 
     protected RefreshToken() {
     }
@@ -45,5 +52,37 @@ public class RefreshToken {
 
     public String getId() {
         return id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public DeviceType getDeviceType() {
+        return deviceType;
+    }
+
+    public void setDeviceType(DeviceType deviceType) {
+        this.deviceType = deviceType;
+    }
+
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    public void setUserAgent(String userAgent) {
+        this.userAgent = userAgent;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiryDate);
+    }
+
+    public boolean isRevoked() {
+        return revoked;
+    }
+
+    public void revoke() {
+        revoked = true;
     }
 }

--- a/src/main/java/com/shootdoori/match/user/dto/AuthTokenResponse.java
+++ b/src/main/java/com/shootdoori/match/user/dto/AuthTokenResponse.java
@@ -1,9 +1,21 @@
 package com.shootdoori.match.user.dto;
 
+import com.shootdoori.match.user.util.GeneratedToken;
+
 public record AuthTokenResponse(
         String accessToken,
         String refreshToken,
         long accessTokenExpiresIn,
         long refreshTokenExpiresIn
 ) {
+
+    public static AuthTokenResponse from(GeneratedToken generatedToken) {
+        AuthToken authToken = generatedToken.authToken();
+        return new AuthTokenResponse(
+            authToken.accessToken(),
+            authToken.refreshToken(),
+            authToken.accessTokenExpiresIn(),
+            authToken.refreshTokenExpiresIn()
+        );
+    }
 }

--- a/src/main/java/com/shootdoori/match/user/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/shootdoori/match/user/dto/TokenRefreshRequest.java
@@ -1,4 +1,4 @@
-package com.shootdoori.match.dto;
+package com.shootdoori.match.user.dto;
 
 public record TokenRefreshRequest(String refreshToken) {
 }

--- a/src/main/java/com/shootdoori/match/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/shootdoori/match/user/repository/RefreshTokenRepository.java
@@ -1,8 +1,10 @@
 package com.shootdoori.match.user.repository;
 
 import com.shootdoori.match.user.domain.RefreshToken;
+import com.shootdoori.match.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
-    
+
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/shootdoori/match/user/service/AuthService.java
+++ b/src/main/java/com/shootdoori/match/user/service/AuthService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 public class AuthService {
 
     private final UserQueryService userQueryService;
@@ -29,7 +30,6 @@ public class AuthService {
         this.refreshTokenRepository = refreshTokenRepository;
     }
 
-    @Transactional
     public AuthTokenResponse login(LoginRequest request, String userAgent) {
         User user = userQueryService.findByEmail(request.email());
         validatePasswordMatch(request, user);
@@ -39,7 +39,7 @@ public class AuthService {
 
         saveRefreshToken(generatedToken);
 
-        return createAuthTokenResponse(generatedToken);
+        return AuthTokenResponse.from(generatedToken);
     }
 
     private void saveRefreshToken(GeneratedToken generatedToken) {
@@ -50,14 +50,5 @@ public class AuthService {
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
             throw new UnauthorizedException(ErrorCode.FAIL_LOGIN);
         }
-    }
-
-    private AuthTokenResponse createAuthTokenResponse(GeneratedToken generatedToken) {
-        return new AuthTokenResponse(
-            generatedToken.authToken().accessToken(),
-            generatedToken.authToken().refreshToken(),
-            generatedToken.authToken().accessTokenExpiresIn(),
-            generatedToken.authToken().refreshTokenExpiresIn()
-        );
     }
 }

--- a/src/main/java/com/shootdoori/match/user/service/TokenRefreshService.java
+++ b/src/main/java/com/shootdoori/match/user/service/TokenRefreshService.java
@@ -1,0 +1,68 @@
+package com.shootdoori.match.user.service;
+
+import com.shootdoori.match.exception.common.ErrorCode;
+import com.shootdoori.match.exception.common.UnauthorizedException;
+import com.shootdoori.match.user.domain.RefreshToken;
+import com.shootdoori.match.user.dto.AuthTokenResponse;
+import com.shootdoori.match.user.dto.TokenRefreshRequest;
+import com.shootdoori.match.user.repository.RefreshTokenRepository;
+import com.shootdoori.match.user.util.GeneratedToken;
+import com.shootdoori.match.user.util.JwtUtil;
+import com.shootdoori.match.user.util.TokenIssuer;
+import io.jsonwebtoken.Claims;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class TokenRefreshService {
+
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenIssuer tokenIssuer;
+
+    public TokenRefreshService(JwtUtil jwtUtil, RefreshTokenRepository refreshTokenRepository,
+        TokenIssuer tokenIssuer) {
+        this.jwtUtil = jwtUtil;
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.tokenIssuer = tokenIssuer;
+    }
+
+    public AuthTokenResponse refresh(TokenRefreshRequest request) {
+        Claims claims = jwtUtil.getClaims(request.refreshToken());
+        String tokenId = claims.getId();
+
+        RefreshToken storedToken = refreshTokenRepository.findById(tokenId)
+            .orElseThrow(() -> new UnauthorizedException(ErrorCode.INVALID_TOKEN));
+
+        revoke(storedToken);
+
+        return reissue(storedToken);
+    }
+
+    private AuthTokenResponse reissue(RefreshToken storedToken) {
+        GeneratedToken newTokens = tokenIssuer.issue(
+            storedToken.getUser(),
+            storedToken.getDeviceType(),
+            storedToken.getUserAgent()
+        );
+
+        refreshTokenRepository.save(newTokens.refreshToken());
+
+        return AuthTokenResponse.from(newTokens);
+    }
+
+    private void revoke(RefreshToken storedToken) {
+        if (storedToken.isRevoked()) {
+            refreshTokenRepository.deleteByUser(storedToken.getUser());
+            throw new UnauthorizedException(ErrorCode.STOLEN_TOKEN_DETECTED);
+        }
+
+        if (storedToken.isExpired()) {
+            refreshTokenRepository.delete(storedToken);
+            throw new UnauthorizedException(ErrorCode.EXPIRED_TOKEN);
+        }
+
+        storedToken.revoke();
+    }
+}

--- a/src/test/java/com/shootdoori/match/user/service/TokenRefreshServiceTest.java
+++ b/src/test/java/com/shootdoori/match/user/service/TokenRefreshServiceTest.java
@@ -1,0 +1,186 @@
+package com.shootdoori.match.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.shootdoori.match.entity.common.Position;
+import com.shootdoori.match.entity.common.SkillLevel;
+import com.shootdoori.match.exception.common.UnauthorizedException;
+import com.shootdoori.match.team.domain.value.UniversityName;
+import com.shootdoori.match.user.domain.DeviceType;
+import com.shootdoori.match.user.domain.RefreshToken;
+import com.shootdoori.match.user.domain.User;
+import com.shootdoori.match.user.domain.value.Bio;
+import com.shootdoori.match.user.domain.value.Department;
+import com.shootdoori.match.user.domain.value.Email;
+import com.shootdoori.match.user.domain.value.KakaoTalkId;
+import com.shootdoori.match.user.domain.value.Password;
+import com.shootdoori.match.user.domain.value.StudentYear;
+import com.shootdoori.match.user.domain.value.UserName;
+import com.shootdoori.match.user.dto.AuthToken;
+import com.shootdoori.match.user.dto.AuthTokenResponse;
+import com.shootdoori.match.user.dto.TokenRefreshRequest;
+import com.shootdoori.match.user.repository.RefreshTokenRepository;
+import com.shootdoori.match.user.util.GeneratedToken;
+import com.shootdoori.match.user.util.JwtUtil;
+import com.shootdoori.match.user.util.TokenIssuer;
+import io.jsonwebtoken.Claims;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TokenRefreshService 테스트")
+class TokenRefreshServiceTest {
+
+    @Mock
+    private JwtUtil jwtUtil;
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+    @Mock
+    private TokenIssuer tokenIssuer;
+
+    private TokenRefreshService tokenRefreshService;
+
+    @BeforeEach
+    void setUp() {
+        tokenRefreshService = new TokenRefreshService(jwtUtil, refreshTokenRepository, tokenIssuer);
+    }
+
+    @Test
+    @DisplayName("토큰 갱신 성공")
+    void refresh_success() {
+        // given
+        String refreshTokenStr = "validRefreshToken";
+        TokenRefreshRequest request = new TokenRefreshRequest(refreshTokenStr);
+        String tokenId = "tokenId";
+
+        Claims claims = mock(Claims.class);
+        given(claims.getId()).willReturn(tokenId);
+
+        User user = createUser();
+        RefreshToken storedToken = createRefreshToken(user, false, LocalDateTime.now().plusDays(1));
+
+        given(jwtUtil.getClaims(refreshTokenStr)).willReturn(claims);
+        given(refreshTokenRepository.findById(tokenId)).willReturn(Optional.of(storedToken));
+
+        GeneratedToken newGeneratedToken = createGeneratedToken(user);
+        given(tokenIssuer.issue(any(User.class), any(DeviceType.class), any())).willReturn(
+            newGeneratedToken);
+
+        // when
+        AuthTokenResponse response = tokenRefreshService.refresh(request);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(storedToken.isRevoked()).isTrue();
+        verify(refreshTokenRepository).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 토큰으로 갱신 시도 시 예외 발생")
+    void refresh_fail_invalid_token() {
+        // given
+        String refreshTokenStr = "invalidRefreshToken";
+        TokenRefreshRequest request = new TokenRefreshRequest(refreshTokenStr);
+        String tokenId = "tokenId";
+
+        Claims claims = mock(Claims.class);
+        given(jwtUtil.getClaims(refreshTokenStr)).willReturn(claims);
+        given(claims.getId()).willReturn(tokenId);
+
+        given(refreshTokenRepository.findById(tokenId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> tokenRefreshService.refresh(request))
+            .isInstanceOf(UnauthorizedException.class);
+    }
+
+    @Test
+    @DisplayName("이미 사용된(Revoked) 토큰으로 갱신 시도 시 예외 발생 및 전체 삭제")
+    void refresh_fail_revoked_token() {
+        // given
+        String refreshTokenStr = "revokedRefreshToken";
+        TokenRefreshRequest request = new TokenRefreshRequest(refreshTokenStr);
+        String tokenId = "tokenId";
+
+        Claims claims = mock(Claims.class);
+        given(claims.getId()).willReturn(tokenId);
+
+        User user = createUser();
+        RefreshToken storedToken = createRefreshToken(user, true, LocalDateTime.now());
+
+        given(jwtUtil.getClaims(refreshTokenStr)).willReturn(claims);
+        given(refreshTokenRepository.findById(tokenId)).willReturn(Optional.of(storedToken));
+
+        // when & then
+        assertThatThrownBy(() -> tokenRefreshService.refresh(request))
+            .isInstanceOf(UnauthorizedException.class);
+        verify(refreshTokenRepository).deleteByUser(user);
+    }
+
+    @Test
+    @DisplayName("만료된 토큰으로 갱신 시도 시 예외 발생 및 삭제")
+    void refresh_fail_expired_token() {
+        // given
+        String refreshTokenStr = "expiredRefreshToken";
+        TokenRefreshRequest request = new TokenRefreshRequest(refreshTokenStr);
+        String tokenId = "tokenId";
+
+        Claims claims = mock(Claims.class);
+        given(claims.getId()).willReturn(tokenId);
+
+        User user = createUser();
+        RefreshToken storedToken = createRefreshToken(user, false,
+            LocalDateTime.now().minusDays(1));
+
+        given(jwtUtil.getClaims(refreshTokenStr)).willReturn(claims);
+        given(refreshTokenRepository.findById(tokenId)).willReturn(Optional.of(storedToken));
+
+        // when & then
+        assertThatThrownBy(() -> tokenRefreshService.refresh(request))
+            .isInstanceOf(UnauthorizedException.class);
+
+        verify(refreshTokenRepository).delete(storedToken);
+    }
+
+    private User createUser() {
+        return new User(
+            new UserName("정상수"),
+            new Email("gamza@kangwon.ac.kr"),
+            new Password("encodedPassword"),
+            Position.FW,
+            SkillLevel.AMATEUR,
+            new KakaoTalkId("kakao123"),
+            new UniversityName("강원대학교"),
+            new Department("컴퓨터공학과"),
+            new StudentYear("23"),
+            new Bio("안녕하세요")
+        );
+    }
+
+    private RefreshToken createRefreshToken(User user, boolean revoked, LocalDateTime expiryDate) {
+        RefreshToken refreshToken = new RefreshToken("tokenId", user, DeviceType.WEB, "userAgent",
+            expiryDate);
+        if (revoked) {
+            refreshToken.revoke();
+        }
+        return refreshToken;
+    }
+
+    private GeneratedToken createGeneratedToken(User user) {
+        AuthToken authToken = new AuthToken("newAccessToken", "newRefreshToken", 3600L, 86400L);
+        RefreshToken refreshToken = new RefreshToken("newTokenId", user, DeviceType.WEB,
+            "userAgent", LocalDateTime.now().plusDays(1));
+        return new GeneratedToken(authToken, refreshToken);
+    }
+}


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
#24 

---

## 🛠️ 뭘 했는지
- refresh token 재발급 API 구현 & 단위 테스트 작성
  - 토큰 갱신 시 기존 토큰 무효화 및 새 토큰 DB 저장
  - 탈취된 토큰(Revoked) 감지 시 해당 사용자 전체 로그아웃 처리


---

## 📷 스크린샷
❌ 

---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
❌ 

---

*PR 확인 부탁드려요! 🙏*