### PR TITLE
feat(match): 매치 생성/조회 기능 구현 및 단위 테스트 작성

### DIFF
--- a/src/main/java/com/shootdoori/match/coordination/controller/MatchController.java
+++ b/src/main/java/com/shootdoori/match/coordination/controller/MatchController.java
@@ -1,6 +1,7 @@
 package com.shootdoori.match.coordination.controller;
 
 import com.shootdoori.match.coordination.service.MatchCommandService;
+import com.shootdoori.match.coordination.service.EnemyTeamQueryService;
 import com.shootdoori.match.coordination.service.MatchQueryService;
 import com.shootdoori.match.dto.EnemyTeamResponseDto;
 import com.shootdoori.match.dto.MatchCreateRequestDto;
@@ -8,7 +9,6 @@ import com.shootdoori.match.dto.MatchCreateResponseDto;
 import com.shootdoori.match.dto.MatchWaitingCancelResponseDto;
 import com.shootdoori.match.dto.MatchWaitingResponseDto;
 import com.shootdoori.match.resolver.LoginUser;
-import com.shootdoori.match.team.service.TeamQueryService;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
@@ -29,9 +29,15 @@ public class MatchController {
 
     private final MatchQueryService matchQueryService;
     private final MatchCommandService matchCommandService;
-    public MatchController(MatchQueryService matchQueryService, MatchCommandService matchCommandService) {
+    private final EnemyTeamQueryService enemyTeamQueryService;
+    public MatchController(
+        MatchQueryService matchQueryService,
+        MatchCommandService matchCommandService,
+        EnemyTeamQueryService enemyTeamQueryService
+    ) {
         this.matchQueryService = matchQueryService;
         this.matchCommandService = matchCommandService;
+        this.enemyTeamQueryService = enemyTeamQueryService;
     }
 
     @PostMapping
@@ -65,6 +71,7 @@ public class MatchController {
         @LoginUser Long loginUserId,
         @PathVariable Long matchId
     ) {
-        return null;
+        return new ResponseEntity<>(enemyTeamQueryService.findEnemyTeam(loginUserId, matchId),
+            HttpStatus.OK);
     }
 }

--- a/src/main/java/com/shootdoori/match/coordination/controller/MatchController.java
+++ b/src/main/java/com/shootdoori/match/coordination/controller/MatchController.java
@@ -7,7 +7,6 @@ import com.shootdoori.match.dto.MatchCreateResponseDto;
 import com.shootdoori.match.dto.MatchWaitingCancelResponseDto;
 import com.shootdoori.match.dto.MatchWaitingResponseDto;
 import com.shootdoori.match.resolver.LoginUser;
-import com.shootdoori.match.team.service.TeamMemberQueryService;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
@@ -27,12 +26,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class MatchController {
 
     private final MatchCommandService matchCommandService;
-    private final TeamMemberQueryService teamMemberQueryService;
-
-    public MatchController(MatchCommandService matchCommandService,
-        TeamMemberQueryService teamMemberQueryService) {
+    public MatchController(MatchCommandService matchCommandService) {
         this.matchCommandService = matchCommandService;
-        this.teamMemberQueryService = teamMemberQueryService;
     }
 
     @PostMapping
@@ -40,11 +35,8 @@ public class MatchController {
         @LoginUser Long loginUserId,
         @RequestBody MatchCreateRequestDto matchCreateRequestDto
     ) {
-        Long homeTeamId = teamMemberQueryService.getTeamIdByUserId(loginUserId);
-        MatchCreateResponseDto responseDto = matchCommandService.create(homeTeamId,
-            matchCreateRequestDto);
-
-        return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
+        return new ResponseEntity<>(matchCommandService.create(loginUserId, matchCreateRequestDto),
+            HttpStatus.CREATED);
     }
 
     @PutMapping("/waiting/{matchWaitingId}/cancel")
@@ -52,7 +44,8 @@ public class MatchController {
         @LoginUser Long loginUserId,
         @PathVariable Long matchWaitingId
     ) {
-        return null;
+        return new ResponseEntity<>(matchCommandService.cancel(loginUserId, matchWaitingId),
+            HttpStatus.OK);
     }
 
     @GetMapping("/waiting/me")

--- a/src/main/java/com/shootdoori/match/coordination/controller/MatchController.java
+++ b/src/main/java/com/shootdoori/match/coordination/controller/MatchController.java
@@ -1,12 +1,14 @@
 package com.shootdoori.match.coordination.controller;
 
 import com.shootdoori.match.coordination.service.MatchCommandService;
+import com.shootdoori.match.coordination.service.MatchQueryService;
 import com.shootdoori.match.dto.EnemyTeamResponseDto;
 import com.shootdoori.match.dto.MatchCreateRequestDto;
 import com.shootdoori.match.dto.MatchCreateResponseDto;
 import com.shootdoori.match.dto.MatchWaitingCancelResponseDto;
 import com.shootdoori.match.dto.MatchWaitingResponseDto;
 import com.shootdoori.match.resolver.LoginUser;
+import com.shootdoori.match.team.service.TeamQueryService;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
@@ -25,8 +27,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/matches")
 public class MatchController {
 
+    private final MatchQueryService matchQueryService;
     private final MatchCommandService matchCommandService;
-    public MatchController(MatchCommandService matchCommandService) {
+    public MatchController(MatchQueryService matchQueryService, MatchCommandService matchCommandService) {
+        this.matchQueryService = matchQueryService;
         this.matchCommandService = matchCommandService;
     }
 
@@ -51,9 +55,9 @@ public class MatchController {
     @GetMapping("/waiting/me")
     public ResponseEntity<Slice<MatchWaitingResponseDto>> findAll(
         @LoginUser Long loginUserId,
-        @PageableDefault(sort = "audit.createdAt", direction = Sort.Direction.DESC) Pageable pageable
+        @PageableDefault(sort = "timeStamp.createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        return null;
+        return new ResponseEntity<>(matchQueryService.findAll(loginUserId, pageable), HttpStatus.OK);
     }
 
     @GetMapping("/{matchId}/enemyTeam")

--- a/src/main/java/com/shootdoori/match/coordination/controller/TeamMatchController.java
+++ b/src/main/java/com/shootdoori/match/coordination/controller/TeamMatchController.java
@@ -1,32 +1,41 @@
 package com.shootdoori.match.coordination.controller;
 
+import com.shootdoori.match.coordination.service.TeamMatchQueryService;
 import com.shootdoori.match.dto.RecentMatchesResponseDto;
 import com.shootdoori.match.resolver.LoginUser;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/teams")
 public class TeamMatchController {
 
+    private final TeamMatchQueryService teamMatchQueryService;
+
+    public TeamMatchController(TeamMatchQueryService teamMatchQueryService) {
+        this.teamMatchQueryService = teamMatchQueryService;
+    }
+
     @GetMapping("/me/matches")
-    public ResponseEntity<List<RecentMatchesResponseDto>> getRecentCompletedMatches(
+    public ResponseEntity<List<RecentMatchesResponseDto>> findRecentCompletedMatches(
         @LoginUser Long loginUserId,
         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate cursorDate,
         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.TIME) LocalTime cursorTime,
-        @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size
+        @RequestParam(defaultValue = "10") @Min(1) @Max(10) int size
     ) {
-        return null;
+        return new ResponseEntity<>(
+            teamMatchQueryService.findRecentCompletedMatches(loginUserId, cursorDate, cursorTime,
+                size), HttpStatus.OK);
     }
 }
 

--- a/src/main/java/com/shootdoori/match/coordination/domain/Match.java
+++ b/src/main/java/com/shootdoori/match/coordination/domain/Match.java
@@ -3,6 +3,7 @@ package com.shootdoori.match.coordination.domain;
 import com.shootdoori.match.entity.common.TimeStamp;
 import com.shootdoori.match.exception.common.ErrorCode;
 import com.shootdoori.match.exception.common.NoPermissionException;
+import com.shootdoori.match.exception.common.NotFoundException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -105,6 +106,20 @@ public class Match {
     public void finish() {
         status.validateFinishable();
         this.status = MatchStatus.FINISHED;
+    }
+
+    public Long findEnemyTeamId(Long loginTeamId) {
+        boolean home = homeTeamId.equals(loginTeamId);
+        boolean away = awayTeamId != null && awayTeamId.equals(loginTeamId);
+
+        if (!home && !away) {
+            throw new NoPermissionException(ErrorCode.MATCH_OPERATION_PERMISSION_DENIED);
+        }
+        if (home && awayTeamId == null) {
+            throw new NotFoundException(ErrorCode.TEAM_NOT_FOUND);
+        }
+
+        return !home ? homeTeamId : awayTeamId;
     }
 
     public void validateHomeTeam(Long loginTeamId) {

--- a/src/main/java/com/shootdoori/match/coordination/domain/Match.java
+++ b/src/main/java/com/shootdoori/match/coordination/domain/Match.java
@@ -113,6 +113,10 @@ public class Match {
         }
     }
 
+    public void validateWaitingStatus() {
+        status.validateWaitingStatus();
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/com/shootdoori/match/coordination/domain/Match.java
+++ b/src/main/java/com/shootdoori/match/coordination/domain/Match.java
@@ -187,5 +187,13 @@ public class Match {
     public MatchStatus getStatus() {
         return status;
     }
+
+    public LocalDateTime getCreatedAt() {
+        return timeStamp.getCreatedAt();
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return timeStamp.getUpdatedAt();
+    }
 }
 

--- a/src/main/java/com/shootdoori/match/coordination/domain/Match.java
+++ b/src/main/java/com/shootdoori/match/coordination/domain/Match.java
@@ -1,6 +1,8 @@
 package com.shootdoori.match.coordination.domain;
 
 import com.shootdoori.match.entity.common.TimeStamp;
+import com.shootdoori.match.exception.common.ErrorCode;
+import com.shootdoori.match.exception.common.NoPermissionException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -47,6 +49,12 @@ public class Match {
     @Column(name = "venue_id", nullable = false)
     private Long venueId;
 
+    @Column(name = "university_only", nullable = false)
+    private boolean universityOnly;
+
+    @Column(name = "message", length = 500)
+    private String message;
+
     @Column(name = "expires_at", nullable = false)
     private LocalDateTime expiresAt;
 
@@ -64,10 +72,14 @@ public class Match {
     }
 
     public Match(Long homeTeamId, LocalDate preferredDate, LocalTime preferredTimeStart,
-        LocalTime preferredTimeEnd, Long venueId, Long homeLineupId) {
+        LocalTime preferredTimeEnd, Long venueId, boolean universityOnly, String message,
+        Long homeLineupId) {
         this.homeTeamId = homeTeamId;
-        this.preferredSchedule = new PreferredSchedule(preferredDate, preferredTimeStart, preferredTimeEnd);
+        this.preferredSchedule = new PreferredSchedule(preferredDate, preferredTimeStart,
+            preferredTimeEnd);
         this.venueId = venueId;
+        this.universityOnly = universityOnly;
+        this.message = message;
         this.homeLineupId = homeLineupId;
         this.expiresAt = calculateExpiresAt(preferredDate);
         this.status = MatchStatus.WAITING;
@@ -93,6 +105,12 @@ public class Match {
     public void finish() {
         status.validateFinishable();
         this.status = MatchStatus.FINISHED;
+    }
+
+    public void validateHomeTeam(Long loginTeamId) {
+        if (!homeTeamId.equals(loginTeamId)) {
+            throw new NoPermissionException(ErrorCode.MATCH_WAITING_OWNERSHIP_VIOLATION);
+        }
     }
 
     public Long getId() {
@@ -133,6 +151,14 @@ public class Match {
 
     public Long getVenueId() {
         return venueId;
+    }
+
+    public boolean isUniversityOnly() {
+        return universityOnly;
+    }
+
+    public String getMessage() {
+        return message;
     }
 
     public LocalDateTime getExpiresAt() {

--- a/src/main/java/com/shootdoori/match/coordination/domain/MatchStatus.java
+++ b/src/main/java/com/shootdoori/match/coordination/domain/MatchStatus.java
@@ -32,6 +32,12 @@ public enum MatchStatus {
         }
     }
 
+    public void validateWaitingStatus() {
+        if (this != WAITING) {
+            throw new IllegalStateException("매치 대기 상태가 아닙니다.");
+        }
+    }
+
     private boolean canMatch() {
         return this == WAITING;
     }

--- a/src/main/java/com/shootdoori/match/coordination/repository/MatchRepository.java
+++ b/src/main/java/com/shootdoori/match/coordination/repository/MatchRepository.java
@@ -3,12 +3,31 @@ package com.shootdoori.match.coordination.repository;
 import com.shootdoori.match.coordination.domain.Match;
 import com.shootdoori.match.coordination.domain.MatchStatus;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MatchRepository extends JpaRepository<Match, Long> {
 
     Slice<Match> findAllByHomeTeamIdAndStatusAndExpiresAtAfter(Long homeTeamId, MatchStatus status,
         LocalDateTime now, Pageable pageable);
+
+    @Query("""
+        select m
+        from Match m
+        where (m.homeTeamId = :teamId or m.awayTeamId = :teamId)
+          and m.status = :status
+          and m.matchAt is not null
+          and m.matchAt < :cursor
+        order by m.matchAt desc, m.id desc
+        """)
+    List<Match> findRecentFinishedMatchesByTeamId(
+        @Param("teamId") Long teamId,
+        @Param("status") MatchStatus status,
+        @Param("cursor") LocalDateTime cursor,
+        Pageable pageable
+    );
 }

--- a/src/main/java/com/shootdoori/match/coordination/repository/MatchRepository.java
+++ b/src/main/java/com/shootdoori/match/coordination/repository/MatchRepository.java
@@ -1,0 +1,8 @@
+package com.shootdoori.match.coordination.repository;
+
+import com.shootdoori.match.coordination.domain.Match;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MatchRepository extends JpaRepository<Match, Long> {
+
+}

--- a/src/main/java/com/shootdoori/match/coordination/repository/MatchRepository.java
+++ b/src/main/java/com/shootdoori/match/coordination/repository/MatchRepository.java
@@ -1,8 +1,14 @@
 package com.shootdoori.match.coordination.repository;
 
 import com.shootdoori.match.coordination.domain.Match;
+import com.shootdoori.match.coordination.domain.MatchStatus;
+import java.time.LocalDateTime;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MatchRepository extends JpaRepository<Match, Long> {
 
+    Slice<Match> findAllByHomeTeamIdAndStatusAndExpiresAtAfter(Long homeTeamId, MatchStatus status,
+        LocalDateTime now, Pageable pageable);
 }

--- a/src/main/java/com/shootdoori/match/coordination/service/EnemyTeamQueryService.java
+++ b/src/main/java/com/shootdoori/match/coordination/service/EnemyTeamQueryService.java
@@ -33,11 +33,6 @@ public class EnemyTeamQueryService {
         Long enemyTeamId = match.findEnemyTeamId(loginTeamId);
         Team enemyTeam = teamQueryService.findByIdForEntity(enemyTeamId);
 
-        return new EnemyTeamResponseDto(
-            enemyTeam.getId(),
-            enemyTeam.getTeamName(),
-            enemyTeam.getUniversityName(),
-            enemyTeam.getDescription()
-        );
+        return EnemyTeamResponseDto.from(enemyTeam);
     }
 }

--- a/src/main/java/com/shootdoori/match/coordination/service/EnemyTeamQueryService.java
+++ b/src/main/java/com/shootdoori/match/coordination/service/EnemyTeamQueryService.java
@@ -1,0 +1,43 @@
+package com.shootdoori.match.coordination.service;
+
+import com.shootdoori.match.coordination.domain.Match;
+import com.shootdoori.match.dto.EnemyTeamResponseDto;
+import com.shootdoori.match.team.domain.Team;
+import com.shootdoori.match.team.service.TeamMemberQueryService;
+import com.shootdoori.match.team.service.TeamQueryService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class EnemyTeamQueryService {
+
+    private final TeamQueryService teamQueryService;
+    private final TeamMemberQueryService teamMemberQueryService;
+    private final MatchQueryService matchQueryService;
+
+    public EnemyTeamQueryService(
+        TeamQueryService teamQueryService, TeamMemberQueryService teamMemberQueryService,
+        MatchQueryService matchQueryService
+    ) {
+        this.teamQueryService = teamQueryService;
+        this.teamMemberQueryService = teamMemberQueryService;
+        this.matchQueryService = matchQueryService;
+    }
+
+    public EnemyTeamResponseDto findEnemyTeam(Long loginUserId, Long matchId) {
+        Long loginTeamId = teamMemberQueryService.getTeamIdByUserId(loginUserId);
+
+        Match match = matchQueryService.findById(matchId);
+
+        Long enemyTeamId = match.findEnemyTeamId(loginTeamId);
+        Team enemyTeam = teamQueryService.findByIdForEntity(enemyTeamId);
+
+        return new EnemyTeamResponseDto(
+            enemyTeam.getId(),
+            enemyTeam.getTeamName(),
+            enemyTeam.getUniversityName(),
+            enemyTeam.getDescription()
+        );
+    }
+}

--- a/src/main/java/com/shootdoori/match/coordination/service/MatchCommandService.java
+++ b/src/main/java/com/shootdoori/match/coordination/service/MatchCommandService.java
@@ -1,0 +1,76 @@
+package com.shootdoori.match.coordination.service;
+
+import com.shootdoori.match.coordination.domain.Match;
+import com.shootdoori.match.coordination.domain.Venue;
+import com.shootdoori.match.coordination.repository.MatchRepository;
+import com.shootdoori.match.dto.MatchCreateRequestDto;
+import com.shootdoori.match.dto.MatchCreateResponseDto;
+import com.shootdoori.match.dto.MatchWaitingCancelResponseDto;
+import com.shootdoori.match.team.service.TeamMemberQueryService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@Transactional
+public class MatchCommandService {
+
+    private final MatchQueryService matchQueryService;
+    private final MatchRepository matchRepository;
+    private final MatchApplicationCommandService matchApplicationCommandService;
+    private final TeamMemberQueryService teamMemberQueryService;
+    private final VenueQueryService venueQueryService;
+
+    public MatchCommandService(
+        MatchQueryService matchQueryService,
+        MatchRepository matchRepository,
+        MatchApplicationCommandService matchApplicationCommandService,
+        TeamMemberQueryService teamMemberQueryService,
+        VenueQueryService venueQueryService
+    ) {
+        this.matchQueryService = matchQueryService;
+        this.matchRepository = matchRepository;
+        this.matchApplicationCommandService = matchApplicationCommandService;
+        this.teamMemberQueryService = teamMemberQueryService;
+        this.venueQueryService = venueQueryService;
+    }
+
+    public MatchCreateResponseDto create(Long loginUserId, MatchCreateRequestDto requestDto) {
+        Long homeTeamId = teamMemberQueryService.getTeamIdByUserId(loginUserId);
+        Venue venue = venueQueryService.findByIdForEntity(requestDto.preferredVenueId());
+
+        Match match = createWaiting(homeTeamId, requestDto, venue);
+        Match saved = matchRepository.save(match);
+        
+        return MatchCreateResponseDto.from(saved, homeTeamId, venue);
+    }
+
+    public MatchWaitingCancelResponseDto cancel(Long loginUserId, Long waitingId) {
+        Long loginTeamId = teamMemberQueryService.getTeamIdByUserId(loginUserId);
+
+        Match waiting = matchQueryService.findById(waitingId);
+        waiting.validateHomeTeam(loginTeamId);
+
+        waiting.cancel();
+        matchApplicationCommandService.rejectAllPending(waiting.getId(), loginTeamId);
+
+        return new MatchWaitingCancelResponseDto(
+            waiting.getId(),
+            waiting.getHomeTeamId(),
+            waiting.getExpiresAt()
+        );
+    }
+
+    private Match createWaiting(Long homeTeamId, MatchCreateRequestDto requestDto, Venue venue) {
+        return new Match(
+            homeTeamId,
+            requestDto.preferredDate(),
+            requestDto.preferredTimeStart(),
+            requestDto.preferredTimeEnd(),
+            venue.getId(),
+            requestDto.universityOnly(),
+            requestDto.message(),
+            requestDto.lineupId()
+        );
+    }
+}

--- a/src/main/java/com/shootdoori/match/coordination/service/MatchQueryService.java
+++ b/src/main/java/com/shootdoori/match/coordination/service/MatchQueryService.java
@@ -3,15 +3,10 @@ package com.shootdoori.match.coordination.service;
 import com.shootdoori.match.coordination.domain.Match;
 import com.shootdoori.match.coordination.domain.MatchStatus;
 import com.shootdoori.match.coordination.repository.MatchRepository;
-import com.shootdoori.match.dto.EnemyTeamResponseDto;
 import com.shootdoori.match.dto.MatchWaitingResponseDto;
 import com.shootdoori.match.exception.common.ErrorCode;
 import com.shootdoori.match.exception.common.NotFoundException;
-import com.shootdoori.match.team.domain.Team;
-import com.shootdoori.match.team.domain.TeamMember;
-import com.shootdoori.match.team.domain.TeamMemberRole;
 import com.shootdoori.match.team.service.TeamMemberQueryService;
-import com.shootdoori.match.user.domain.User;
 import java.time.LocalDateTime;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -48,17 +43,6 @@ public class MatchQueryService {
                 LocalDateTime.now(),
                 pageable
             )
-            .map(match -> new MatchWaitingResponseDto(
-                match.getId(),
-                match.getHomeTeamId(),
-                match.getPreferredDate(),
-                match.getPreferredTimeStart(),
-                match.getPreferredTimeEnd(),
-                match.getVenueId(),
-                match.isUniversityOnly(),
-                match.getMessage(),
-                match.getExpiresAt(),
-                match.getHomeLineupId()
-            ));
+            .map(MatchWaitingResponseDto::from);
     }
 }

--- a/src/main/java/com/shootdoori/match/coordination/service/MatchQueryService.java
+++ b/src/main/java/com/shootdoori/match/coordination/service/MatchQueryService.java
@@ -3,18 +3,31 @@ package com.shootdoori.match.coordination.service;
 import com.shootdoori.match.coordination.domain.Match;
 import com.shootdoori.match.coordination.domain.MatchStatus;
 import com.shootdoori.match.coordination.repository.MatchRepository;
-import com.shootdoori.match.exception.common.BusinessException;
+import com.shootdoori.match.dto.EnemyTeamResponseDto;
+import com.shootdoori.match.dto.MatchWaitingResponseDto;
 import com.shootdoori.match.exception.common.ErrorCode;
 import com.shootdoori.match.exception.common.NotFoundException;
+import com.shootdoori.match.team.domain.Team;
+import com.shootdoori.match.team.domain.TeamMember;
+import com.shootdoori.match.team.domain.TeamMemberRole;
+import com.shootdoori.match.team.service.TeamMemberQueryService;
+import com.shootdoori.match.user.domain.User;
+import java.time.LocalDateTime;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
 public class MatchQueryService {
+
+    private final TeamMemberQueryService teamMemberQueryService;
     private final MatchRepository matchRepository;
 
-    public MatchQueryService(MatchRepository matchRepository) {
+    public MatchQueryService(TeamMemberQueryService teamMemberQueryService,
+        MatchRepository matchRepository) {
+        this.teamMemberQueryService = teamMemberQueryService;
         this.matchRepository = matchRepository;
     }
 
@@ -24,5 +37,28 @@ public class MatchQueryService {
         waiting.validateWaitingStatus();
 
         return waiting;
+    }
+
+    public Slice<MatchWaitingResponseDto> findAll(Long loginUserId, Pageable pageable) {
+        Long loginTeamId = teamMemberQueryService.getTeamIdByUserId(loginUserId);
+
+        return matchRepository.findAllByHomeTeamIdAndStatusAndExpiresAtAfter(
+                loginTeamId,
+                MatchStatus.WAITING,
+                LocalDateTime.now(),
+                pageable
+            )
+            .map(match -> new MatchWaitingResponseDto(
+                match.getId(),
+                match.getHomeTeamId(),
+                match.getPreferredDate(),
+                match.getPreferredTimeStart(),
+                match.getPreferredTimeEnd(),
+                match.getVenueId(),
+                match.isUniversityOnly(),
+                match.getMessage(),
+                match.getExpiresAt(),
+                match.getHomeLineupId()
+            ));
     }
 }

--- a/src/main/java/com/shootdoori/match/coordination/service/MatchQueryService.java
+++ b/src/main/java/com/shootdoori/match/coordination/service/MatchQueryService.java
@@ -1,0 +1,31 @@
+package com.shootdoori.match.coordination.service;
+
+import com.shootdoori.match.coordination.domain.Match;
+import com.shootdoori.match.coordination.domain.MatchStatus;
+import com.shootdoori.match.coordination.repository.MatchRepository;
+import com.shootdoori.match.exception.common.BusinessException;
+import com.shootdoori.match.exception.common.ErrorCode;
+import com.shootdoori.match.exception.common.NotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class MatchQueryService {
+    private final MatchRepository matchRepository;
+
+    public MatchQueryService(MatchRepository matchRepository) {
+        this.matchRepository = matchRepository;
+    }
+
+    public Match findById(Long waitingId) {
+        Match waiting = matchRepository.findById(waitingId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.MATCH_WAITING_NOT_FOUND));
+
+        if (waiting.getStatus() != MatchStatus.WAITING) {
+            throw new NotFoundException(ErrorCode.MATCH_WAITING_NOT_FOUND);
+        }
+
+        return waiting;
+    }
+}

--- a/src/main/java/com/shootdoori/match/coordination/service/MatchQueryService.java
+++ b/src/main/java/com/shootdoori/match/coordination/service/MatchQueryService.java
@@ -21,10 +21,7 @@ public class MatchQueryService {
     public Match findById(Long waitingId) {
         Match waiting = matchRepository.findById(waitingId)
             .orElseThrow(() -> new NotFoundException(ErrorCode.MATCH_WAITING_NOT_FOUND));
-
-        if (waiting.getStatus() != MatchStatus.WAITING) {
-            throw new NotFoundException(ErrorCode.MATCH_WAITING_NOT_FOUND);
-        }
+        waiting.validateWaitingStatus();
 
         return waiting;
     }

--- a/src/main/java/com/shootdoori/match/coordination/service/TeamMatchQueryService.java
+++ b/src/main/java/com/shootdoori/match/coordination/service/TeamMatchQueryService.java
@@ -1,0 +1,60 @@
+package com.shootdoori.match.coordination.service;
+
+import com.shootdoori.match.coordination.domain.Match;
+import com.shootdoori.match.coordination.domain.MatchStatus;
+import com.shootdoori.match.coordination.repository.MatchRepository;
+import com.shootdoori.match.dto.RecentMatchesResponseDto;
+import com.shootdoori.match.team.service.TeamMemberQueryService;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class TeamMatchQueryService {
+
+    private final TeamMemberQueryService teamMemberQueryService;
+    private final MatchRepository matchRepository;
+
+    public TeamMatchQueryService(
+        TeamMemberQueryService teamMemberQueryService,
+        MatchRepository matchRepository
+    ) {
+        this.teamMemberQueryService = teamMemberQueryService;
+        this.matchRepository = matchRepository;
+    }
+
+    public List<RecentMatchesResponseDto> findRecentCompletedMatches(
+        Long loginUserId,
+        LocalDate cursorDate,
+        LocalTime cursorTime,
+        int size
+    ) {
+        Long teamId = teamMemberQueryService.getTeamIdByUserId(loginUserId);
+        LocalDateTime cursor = createCursor(cursorDate, cursorTime);
+        int fetchSize = Math.min(size, 10);
+        Pageable pageable = PageRequest.of(0, fetchSize);
+
+        return matchRepository.findRecentFinishedMatchesByTeamId(
+                teamId,
+                MatchStatus.FINISHED,
+                cursor,
+                pageable
+            )
+            .stream()
+            .map(RecentMatchesResponseDto::from)
+            .toList();
+    }
+
+    private LocalDateTime createCursor(LocalDate cursorDate, LocalTime cursorTime) {
+        if (cursorDate == null || cursorTime == null) {
+            return LocalDateTime.MAX;
+        }
+        return LocalDateTime.of(cursorDate, cursorTime);
+    }
+}

--- a/src/main/java/com/shootdoori/match/dto/EnemyTeamResponseDto.java
+++ b/src/main/java/com/shootdoori/match/dto/EnemyTeamResponseDto.java
@@ -1,8 +1,19 @@
 package com.shootdoori.match.dto;
 
+import com.shootdoori.match.team.domain.Team;
+
 public record EnemyTeamResponseDto(Long teamId,
                                    String teamName,
                                    String universityName,
                                    String description
 ) {
+
+    public static EnemyTeamResponseDto from(Team enemyTeam) {
+        return new EnemyTeamResponseDto(
+            enemyTeam.getId(),
+            enemyTeam.getTeamName(),
+            enemyTeam.getUniversityName(),
+            enemyTeam.getDescription()
+        );
+    }
 }

--- a/src/main/java/com/shootdoori/match/dto/EnemyTeamResponseDto.java
+++ b/src/main/java/com/shootdoori/match/dto/EnemyTeamResponseDto.java
@@ -2,10 +2,7 @@ package com.shootdoori.match.dto;
 
 public record EnemyTeamResponseDto(Long teamId,
                                    String teamName,
-                                   Long captainId,
-                                   String captainName,
                                    String universityName,
-                                   Integer memberCount,
                                    String description
 ) {
 }

--- a/src/main/java/com/shootdoori/match/dto/MatchWaitingResponseDto.java
+++ b/src/main/java/com/shootdoori/match/dto/MatchWaitingResponseDto.java
@@ -1,5 +1,6 @@
 package com.shootdoori.match.dto;
 
+import com.shootdoori.match.coordination.domain.Match;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -16,4 +17,19 @@ public record MatchWaitingResponseDto(
     LocalDateTime expiresAt,
     Long lineup1Id
 ) {
+
+    public static MatchWaitingResponseDto from(Match match) {
+        return new MatchWaitingResponseDto(
+            match.getId(),
+            match.getHomeTeamId(),
+            match.getPreferredDate(),
+            match.getPreferredTimeStart(),
+            match.getPreferredTimeEnd(),
+            match.getVenueId(),
+            match.isUniversityOnly(),
+            match.getMessage(),
+            match.getExpiresAt(),
+            match.getHomeLineupId()
+        );
+    }
 }

--- a/src/main/java/com/shootdoori/match/dto/RecentMatchesResponseDto.java
+++ b/src/main/java/com/shootdoori/match/dto/RecentMatchesResponseDto.java
@@ -1,37 +1,37 @@
 package com.shootdoori.match.dto;
 
+import com.shootdoori.match.coordination.domain.Match;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public record RecentMatchesResponseDto(
     Long matchId,
-    Long createTeamId,
-    Long requestTeamId,
-    Long lineup1Id,
-    Long lineup2Id,
-    String createTeamName,
-    String requestTeamName,
+    Long homeTeamId,
+    Long awayTeamId,
+    Long homeLineupId,
+    Long awayLineupId,
     LocalDate matchDate,
     LocalTime matchTime,
-    String venueName,
+    Long venueId,
     LocalDateTime createdAt,
     LocalDateTime updatedAt
 ) {
-    public static RecentMatchesResponseDto from(MatchSummaryProjection matchSummaryProjection) {
+
+    public static RecentMatchesResponseDto from(Match match) {
+        LocalDateTime matchAt = match.getMatchAt();
+
         return new RecentMatchesResponseDto(
-            matchSummaryProjection.matchId(),
-            matchSummaryProjection.createTeamId(),
-            matchSummaryProjection.requestTeamId(),
-            matchSummaryProjection.createTeamLineupId(),
-            matchSummaryProjection.requestTeamLineupId(),
-            matchSummaryProjection.createTeamName(),
-            matchSummaryProjection.requestTeamName(),
-            matchSummaryProjection.matchDate(),
-            matchSummaryProjection.matchTime(),
-            matchSummaryProjection.venueName(),
-            matchSummaryProjection.createdAt(),
-            matchSummaryProjection.updatedAt()
+            match.getId(),
+            match.getHomeTeamId(),
+            match.getAwayTeamId(),
+            match.getHomeLineupId(),
+            match.getAwayLineupId(),
+            matchAt.toLocalDate(),
+            matchAt.toLocalTime(),
+            match.getVenueId(),
+            match.getCreatedAt(),
+            match.getUpdatedAt()
         );
     }
 }

--- a/src/test/java/com/shootdoori/match/coordination/domain/MatchStatusTest.java
+++ b/src/test/java/com/shootdoori/match/coordination/domain/MatchStatusTest.java
@@ -22,7 +22,8 @@ class MatchStatusTest {
     @DisplayName("매치됨/취소됨/종료됨 상태는 매칭이 불가능하다")
     void validateMatchable_fail(MatchStatus status) {
         // when & then
-        assertThatThrownBy(() -> status.validateMatchable()).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> status.validateMatchable()).isInstanceOf(
+            IllegalStateException.class);
     }
 
     @ParameterizedTest
@@ -38,7 +39,8 @@ class MatchStatusTest {
     @DisplayName("취소됨/종료됨 상태는 취소가 불가능하다")
     void validateCancelable_fail(MatchStatus status) {
         // when & then
-        assertThatThrownBy(() -> status.validateCancelable()).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> status.validateCancelable()).isInstanceOf(
+            IllegalStateException.class);
     }
 
     @ParameterizedTest
@@ -54,6 +56,24 @@ class MatchStatusTest {
     @DisplayName("대기중/취소됨/종료됨 상태는 종료가 불가능하다")
     void validateFinishable_fail(MatchStatus status) {
         // when & then
-        assertThatThrownBy(() -> status.validateFinishable()).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> status.validateFinishable()).isInstanceOf(
+            IllegalStateException.class);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = MatchStatus.class, names = "WAITING")
+    @DisplayName("대기 상태에서는 대기 상태 검증이 통과한다")
+    void validateWaitingStatus_success(MatchStatus status) {
+        // when & then
+        assertThatCode(() -> status.validateWaitingStatus()).doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = MatchStatus.class, names = {"MATCHED", "CANCELED", "FINISHED"})
+    @DisplayName("대기 상태가 아니면 대기 상태 검증 시 예외가 발생한다")
+    void validateWaitingStatus_fail(MatchStatus status) {
+        // when & then
+        assertThatThrownBy(() -> status.validateWaitingStatus()).isInstanceOf(
+            IllegalStateException.class);
     }
 }

--- a/src/test/java/com/shootdoori/match/coordination/domain/MatchTest.java
+++ b/src/test/java/com/shootdoori/match/coordination/domain/MatchTest.java
@@ -143,6 +143,27 @@ class MatchTest {
         assertThatThrownBy(() -> finishedMatch.finish()).isInstanceOf(IllegalStateException.class);
     }
 
+    @Test
+    @DisplayName("대기 상태에서는 validateWaitingStatus 검증을 통과한다")
+    void validateWaitingStatus_대기상태_성공() {
+        // given
+        Match waitingMatch = createMatch();
+
+        // when & then
+        waitingMatch.validateWaitingStatus();
+    }
+
+    @Test
+    @DisplayName("대기 상태가 아니면 validateWaitingStatus 호출 시 예외가 발생한다")
+    void validateWaitingStatus_대기상태아니면_실패() {
+        // given
+        Match matchedMatch = createMatchedMatch();
+
+        // when & then
+        assertThatThrownBy(matchedMatch::validateWaitingStatus)
+            .isInstanceOf(IllegalStateException.class);
+    }
+
     private Match createMatch() {
         return new Match(
             HOME_TEAM_ID,

--- a/src/test/java/com/shootdoori/match/coordination/domain/MatchTest.java
+++ b/src/test/java/com/shootdoori/match/coordination/domain/MatchTest.java
@@ -19,6 +19,8 @@ class MatchTest {
     private static final LocalDate PREFERRED_DATE = LocalDate.of(2026, 2, 10);
     private static final LocalTime PREFERRED_TIME_START = LocalTime.of(14, 0);
     private static final LocalTime PREFERRED_TIME_END = LocalTime.of(16, 0);
+    private static final Boolean UNIVERSITY_ONLY = true;
+    private static final String MESSAGE = "좋은 경기해요!";
 
     @Test
     @DisplayName("매치 생성 시 만료시간은 선호 날짜 하루 전 23:59:59로 계산된다")
@@ -57,6 +59,8 @@ class MatchTest {
         assertThat(match.getPreferredTimeStart()).isEqualTo(PREFERRED_TIME_START);
         assertThat(match.getPreferredTimeEnd()).isEqualTo(PREFERRED_TIME_END);
         assertThat(match.getVenueId()).isEqualTo(VENUE_ID);
+        assertThat(match.isUniversityOnly()).isEqualTo(UNIVERSITY_ONLY);
+        assertThat(match.getMessage()).isEqualTo(MESSAGE);
         assertThat(match.getStatus()).isEqualTo(MatchStatus.WAITING);
         assertThat(match.getAwayTeamId()).isNull();
         assertThat(match.getAwayLineupId()).isNull();
@@ -146,6 +150,8 @@ class MatchTest {
             PREFERRED_TIME_START,
             PREFERRED_TIME_END,
             VENUE_ID,
+            UNIVERSITY_ONLY,
+            MESSAGE,
             HOME_LINEUP_ID
         );
     }

--- a/src/test/java/com/shootdoori/match/coordination/service/MatchCommandServiceTest.java
+++ b/src/test/java/com/shootdoori/match/coordination/service/MatchCommandServiceTest.java
@@ -1,0 +1,116 @@
+package com.shootdoori.match.coordination.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.shootdoori.match.coordination.domain.Match;
+import com.shootdoori.match.coordination.domain.MatchStatus;
+import com.shootdoori.match.coordination.domain.Venue;
+import com.shootdoori.match.coordination.repository.MatchRepository;
+import com.shootdoori.match.dto.MatchCreateRequestDto;
+import com.shootdoori.match.dto.MatchCreateResponseDto;
+import com.shootdoori.match.dto.MatchWaitingCancelResponseDto;
+import com.shootdoori.match.team.service.TeamMemberQueryService;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class MatchCommandServiceTest {
+
+    @Mock
+    private MatchQueryService matchQueryService;
+    @Mock
+    private MatchRepository matchRepository;
+    @Mock
+    private MatchApplicationCommandService matchApplicationCommandService;
+    @Mock
+    private TeamMemberQueryService teamMemberQueryService;
+    @Mock
+    private VenueQueryService venueQueryService;
+
+    private MatchCommandService matchCommandService;
+
+    @BeforeEach
+    void setUp() {
+        matchCommandService = new MatchCommandService(
+            matchQueryService,
+            matchRepository,
+            matchApplicationCommandService,
+            teamMemberQueryService,
+            venueQueryService
+        );
+    }
+
+    @Test
+    @DisplayName("매치 조율을 생성하면 팀 정보를 변환해 저장하고 응답을 반환한다")
+    void create_success() {
+        Long loginUserId = 10L;
+        Long homeTeamId = 100L;
+        Long venueId = 5L;
+
+        MatchCreateRequestDto requestDto = new MatchCreateRequestDto(
+            LocalDate.of(2026, 3, 20),
+            LocalTime.of(14, 0),
+            LocalTime.of(16, 0),
+            venueId,
+            true,
+            "즐겜해요",
+            7L
+        );
+
+        Venue venue = mock(Venue.class);
+        given(venue.getId()).willReturn(venueId);
+        given(venue.getName()).willReturn("강원대학교 대운동장");
+        given(venue.getAddress()).willReturn("춘천");
+
+        given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(homeTeamId);
+        given(venueQueryService.findByIdForEntity(venueId)).willReturn(venue);
+
+        Match saved = mock(Match.class);
+        given(matchRepository.save(any(Match.class))).willReturn(saved);
+
+        MatchCreateResponseDto response = matchCommandService.create(loginUserId, requestDto);
+
+        assertThat(response.teamId()).isEqualTo(homeTeamId);
+        assertThat(response.venueId()).isEqualTo(venueId);
+    }
+
+    @Test
+    @DisplayName("매치 조율을 취소하면 취소 처리 후 대기 중인 요청을 거절한다")
+    void cancel_success() {
+        Long loginUserId = 10L;
+        Long loginTeamId = 100L;
+        Long waitingId = 1000L;
+
+        Match waiting = new Match(
+            loginTeamId,
+            LocalDate.of(2026, 3, 20),
+            LocalTime.of(14, 0),
+            LocalTime.of(16, 0),
+            5L,
+            true,
+            "매치 요청",
+            7L
+        );
+        ReflectionTestUtils.setField(waiting, "id", waitingId);
+
+        given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(loginTeamId);
+        given(matchQueryService.findById(waitingId)).willReturn(waiting);
+
+        MatchWaitingCancelResponseDto response = matchCommandService.cancel(loginUserId, waitingId);
+
+        assertThat(response.waitingId()).isEqualTo(waitingId);
+        assertThat(response.teamId()).isEqualTo(loginTeamId);
+        assertThat(response.expiresAt()).isEqualTo(waiting.getExpiresAt());
+        assertThat(waiting.getStatus()).isEqualTo(MatchStatus.CANCELED);
+    }
+}

--- a/src/test/java/com/shootdoori/match/user/service/UserCommandServiceTest.java
+++ b/src/test/java/com/shootdoori/match/user/service/UserCommandServiceTest.java
@@ -18,6 +18,7 @@ import com.shootdoori.match.user.domain.value.UserName;
 import com.shootdoori.match.user.dto.ProfileResponse;
 import com.shootdoori.match.user.dto.ProfileUpdateRequest;
 import com.shootdoori.match.user.mapper.UserMapper;
+import com.shootdoori.match.user.repository.RefreshTokenRepository;
 import com.shootdoori.match.user.repository.UserRepository;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,13 +41,15 @@ class UserCommandServiceTest {
     private UserMapper userMapper;
     @Mock
     private UserQueryService userQueryService;
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
 
     private UserCommandService userCommandService;
 
     @BeforeEach
     void setUp() {
         userCommandService = new UserCommandService(userRepository, passwordEncoder, userMapper,
-            userQueryService);
+            userQueryService, refreshTokenRepository);
     }
 
     @Test


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
Closes #36 

---

## 🛠️ 뭘 했는지
### 변경 사항
- 매치 생성 및 취소 로직 구현
- 본인 팀 매치 대기 목록 조회 API 추가
- 상대 팀 정보 조회 API 구현
- 본인 팀 최근 완료 경기 조회 API 추가
- `universityOnly`, `message` 컬럼 추가

### 리팩토링
- 매치 조회 시 대기 상태 검증을 도메인 메서드로 위임
- 응답 DTO 매핑을 from() 정적 팩토리 메서드 방식으로 통일
  - MatchWaitingResponseDto.from()
  - EnemyTeamResponseDto.from()

### 테스트
- Match / MatchStatus 단위 테스트
- MatchCommandService 단위 테스트

---

## 📷 스크린샷
❌ 

---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
- `EnemyTeamQueryService`를 보면 team, teamMember, Match 도메인을 모두 알게된 상태인데 피드백해주시면 감사하겠습니다.

---

*PR 확인 부탁드려요! 🙏*