### PR TITLE
feat(match-application): 매치 신청 지원/수락/거절/취소 API 구현 및 단위 테스트 작성

### DIFF
--- a/src/main/java/com/shootdoori/match/coordination/controller/MatchApplicationController.java
+++ b/src/main/java/com/shootdoori/match/coordination/controller/MatchApplicationController.java
@@ -1,9 +1,15 @@
 package com.shootdoori.match.coordination.controller;
 
 import com.shootdoori.match.coordination.service.MatchApplicationCommandService;
-import com.shootdoori.match.dto.*;
+import com.shootdoori.match.dto.MatchConfirmedResponseDto;
+import com.shootdoori.match.dto.MatchRequestHistoryResponseDto;
+import com.shootdoori.match.dto.MatchRequestRequestDto;
+import com.shootdoori.match.dto.MatchRequestResponseDto;
+import com.shootdoori.match.dto.MatchWaitingResponseDto;
 import com.shootdoori.match.resolver.LoginUser;
 import com.shootdoori.match.team.service.TeamMemberQueryService;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
@@ -11,10 +17,15 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/matches")
@@ -37,7 +48,9 @@ public class MatchApplicationController {
         @PathVariable Long waitingId,
         @RequestBody MatchRequestRequestDto requestDto
     ) {
-        return null;
+        return new ResponseEntity<>(
+            matchApplicationCommandService.apply(loginUserId, waitingId, requestDto),
+            HttpStatus.CREATED);
     }
 
     @PutMapping("/requests/{requestId}/accept")
@@ -87,10 +100,6 @@ public class MatchApplicationController {
         @LoginUser Long loginUserId,
         @PathVariable Long requestId
     ) {
-        Long requestTeamId = teamMemberQueryService.getTeamIdByUserId(loginUserId);
-        MatchRequestResponseDto responseDto = matchApplicationCommandService.cancelRequest(
-            requestTeamId, requestId
-        );
-        return ResponseEntity.ok(responseDto);
+        return null;
     }
 }

--- a/src/main/java/com/shootdoori/match/coordination/controller/MatchApplicationController.java
+++ b/src/main/java/com/shootdoori/match/coordination/controller/MatchApplicationController.java
@@ -55,7 +55,8 @@ public class MatchApplicationController {
         @LoginUser Long loginUserId,
         @PathVariable Long requestId
     ) {
-        return null;
+        return new ResponseEntity<>(matchApplicationCommandService.accept(loginUserId,
+            requestId), HttpStatus.OK);
     }
 
     @PutMapping("/requests/{requestId}/reject")

--- a/src/main/java/com/shootdoori/match/coordination/controller/MatchApplicationController.java
+++ b/src/main/java/com/shootdoori/match/coordination/controller/MatchApplicationController.java
@@ -32,14 +32,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class MatchApplicationController {
 
     private final MatchApplicationCommandService matchApplicationCommandService;
-    private final TeamMemberQueryService teamMemberQueryService;
 
     public MatchApplicationController(
-        MatchApplicationCommandService matchApplicationCommandService,
-        TeamMemberQueryService teamMemberQueryService
+        MatchApplicationCommandService matchApplicationCommandService
     ) {
         this.matchApplicationCommandService = matchApplicationCommandService;
-        this.teamMemberQueryService = teamMemberQueryService;
     }
 
     @PostMapping("/{waitingId}/request")
@@ -101,6 +98,7 @@ public class MatchApplicationController {
         @LoginUser Long loginUserId,
         @PathVariable Long requestId
     ) {
-        return null;
+        return new ResponseEntity<>(matchApplicationCommandService.cancel(loginUserId,
+            requestId), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/shootdoori/match/coordination/controller/MatchApplicationController.java
+++ b/src/main/java/com/shootdoori/match/coordination/controller/MatchApplicationController.java
@@ -3,8 +3,8 @@ package com.shootdoori.match.coordination.controller;
 import com.shootdoori.match.coordination.service.MatchApplicationCommandService;
 import com.shootdoori.match.dto.MatchConfirmedResponseDto;
 import com.shootdoori.match.dto.MatchRequestHistoryResponseDto;
-import com.shootdoori.match.dto.MatchRequestRequestDto;
-import com.shootdoori.match.dto.MatchRequestResponseDto;
+import com.shootdoori.match.dto.MatchApplicationRequestDto;
+import com.shootdoori.match.dto.MatchApplicationResponseDto;
 import com.shootdoori.match.dto.MatchWaitingResponseDto;
 import com.shootdoori.match.resolver.LoginUser;
 import com.shootdoori.match.team.service.TeamMemberQueryService;
@@ -40,10 +40,10 @@ public class MatchApplicationController {
     }
 
     @PostMapping("/{waitingId}/request")
-    public ResponseEntity<MatchRequestResponseDto> apply(
+    public ResponseEntity<MatchApplicationResponseDto> apply(
         @LoginUser Long loginUserId,
         @PathVariable Long waitingId,
-        @RequestBody MatchRequestRequestDto requestDto
+        @RequestBody MatchApplicationRequestDto requestDto
     ) {
         return new ResponseEntity<>(
             matchApplicationCommandService.apply(loginUserId, waitingId, requestDto),
@@ -60,7 +60,7 @@ public class MatchApplicationController {
     }
 
     @PutMapping("/requests/{requestId}/reject")
-    public ResponseEntity<MatchRequestResponseDto> reject(
+    public ResponseEntity<MatchApplicationResponseDto> reject(
         @LoginUser Long loginUserId,
         @PathVariable Long requestId
     ) {
@@ -79,7 +79,7 @@ public class MatchApplicationController {
     }
 
     @GetMapping("/receive/me/pending")
-    public ResponseEntity<Slice<MatchRequestResponseDto>> findReceivedPendingRequests(
+    public ResponseEntity<Slice<MatchApplicationResponseDto>> findReceivedPendingRequests(
         @LoginUser Long loginUserId,
         @PageableDefault(sort = "requestAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
@@ -95,7 +95,7 @@ public class MatchApplicationController {
     }
 
     @DeleteMapping("/requests/{requestId}")
-    public ResponseEntity<MatchRequestResponseDto> cancel(
+    public ResponseEntity<MatchApplicationResponseDto> cancel(
         @LoginUser Long loginUserId,
         @PathVariable Long requestId
     ) {

--- a/src/main/java/com/shootdoori/match/coordination/controller/MatchApplicationController.java
+++ b/src/main/java/com/shootdoori/match/coordination/controller/MatchApplicationController.java
@@ -66,7 +66,8 @@ public class MatchApplicationController {
         @LoginUser Long loginUserId,
         @PathVariable Long requestId
     ) {
-        return null;
+        return new ResponseEntity<>(matchApplicationCommandService.reject(loginUserId,
+            requestId), HttpStatus.OK);
     }
 
     @GetMapping("/waiting")

--- a/src/main/java/com/shootdoori/match/coordination/domain/Match.java
+++ b/src/main/java/com/shootdoori/match/coordination/domain/Match.java
@@ -124,7 +124,13 @@ public class Match {
 
     public void validateHomeTeam(Long loginTeamId) {
         if (!homeTeamId.equals(loginTeamId)) {
-            throw new NoPermissionException(ErrorCode.MATCH_WAITING_OWNERSHIP_VIOLATION);
+            throw new NoPermissionException(ErrorCode.MATCH_OPERATION_PERMISSION_DENIED);
+        }
+    }
+
+    public void validateNotApplyingToOwnTeam(Long requestTeamId) {
+        if (homeTeamId.equals(requestTeamId)) {
+            throw new IllegalStateException("자기 팀에는 매치 신청할 수 없습니다.");
         }
     }
 

--- a/src/main/java/com/shootdoori/match/coordination/domain/Match.java
+++ b/src/main/java/com/shootdoori/match/coordination/domain/Match.java
@@ -202,4 +202,3 @@ public class Match {
         return timeStamp.getUpdatedAt();
     }
 }
-

--- a/src/main/java/com/shootdoori/match/coordination/repository/MatchApplicationRepository.java
+++ b/src/main/java/com/shootdoori/match/coordination/repository/MatchApplicationRepository.java
@@ -1,0 +1,18 @@
+package com.shootdoori.match.coordination.repository;
+
+import com.shootdoori.match.coordination.domain.MatchApplication;
+import com.shootdoori.match.coordination.domain.MatchApplicationStatus;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MatchApplicationRepository extends JpaRepository<MatchApplication, Long> {
+
+    boolean existsByMatchIdAndRequestTeamIdAndStatus(
+        Long matchId,
+        Long requestTeamId,
+        MatchApplicationStatus status
+    );
+
+    List<MatchApplication> findAllByMatchIdAndStatus(Long matchId, MatchApplicationStatus status);
+}

--- a/src/main/java/com/shootdoori/match/coordination/service/MatchApplicationCommandService.java
+++ b/src/main/java/com/shootdoori/match/coordination/service/MatchApplicationCommandService.java
@@ -4,9 +4,11 @@ import com.shootdoori.match.coordination.domain.Match;
 import com.shootdoori.match.coordination.domain.MatchApplication;
 import com.shootdoori.match.coordination.domain.MatchApplicationStatus;
 import com.shootdoori.match.coordination.repository.MatchApplicationRepository;
+import com.shootdoori.match.dto.MatchConfirmedResponseDto;
 import com.shootdoori.match.dto.MatchRequestRequestDto;
 import com.shootdoori.match.dto.MatchRequestResponseDto;
 import com.shootdoori.match.team.service.TeamMemberQueryService;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,6 +46,23 @@ public class MatchApplicationCommandService {
         MatchApplication saved = matchApplicationRepository.save(matchApplication);
 
         return MatchRequestResponseDto.from(saved, waiting);
+    }
+
+    public MatchConfirmedResponseDto accept(Long loginUserId, Long requestId) {
+        Long loginTeamId = teamMemberQueryService.getTeamIdByUserId(loginUserId);
+        MatchApplication accepted = matchApplicationQueryService.findByIdForEntity(requestId);
+
+        Match waiting = matchQueryService.findById(accepted.getMatchId());
+        waiting.validateHomeTeam(loginTeamId);
+
+        accepted.accept(loginTeamId);
+        rejectAllPending(waiting.getId(), loginTeamId);
+
+        LocalDateTime confirmedAt = waiting.getPreferredDate()
+            .atTime(waiting.getPreferredTimeStart());
+        waiting.match(accepted.getRequestTeamId(), accepted.getLineupId(), confirmedAt);
+
+        return MatchConfirmedResponseDto.from(waiting);
     }
 
     public MatchRequestResponseDto reject(Long loginUserId, Long requestId) {

--- a/src/main/java/com/shootdoori/match/coordination/service/MatchApplicationCommandService.java
+++ b/src/main/java/com/shootdoori/match/coordination/service/MatchApplicationCommandService.java
@@ -1,0 +1,60 @@
+package com.shootdoori.match.coordination.service;
+
+import com.shootdoori.match.coordination.domain.Match;
+import com.shootdoori.match.coordination.domain.MatchApplication;
+import com.shootdoori.match.coordination.domain.MatchApplicationStatus;
+import com.shootdoori.match.coordination.repository.MatchApplicationRepository;
+import com.shootdoori.match.dto.MatchConfirmedResponseDto;
+import com.shootdoori.match.dto.MatchRequestRequestDto;
+import com.shootdoori.match.dto.MatchRequestResponseDto;
+import com.shootdoori.match.exception.common.DuplicatedException;
+import com.shootdoori.match.exception.common.ErrorCode;
+import com.shootdoori.match.exception.common.NoPermissionException;
+import com.shootdoori.match.exception.common.NotFoundException;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class MatchApplicationCommandService {
+
+    private final MatchQueryService matchQueryService;
+    private final MatchApplicationQueryService matchApplicationQueryService;
+    private final MatchApplicationRepository matchApplicationRepository;
+
+    public MatchApplicationCommandService(
+        MatchQueryService matchQueryService,
+        MatchApplicationQueryService matchApplicationQueryService,
+        MatchApplicationRepository matchApplicationRepository
+    ) {
+        this.matchQueryService = matchQueryService;
+        this.matchApplicationQueryService = matchApplicationQueryService;
+        this.matchApplicationRepository = matchApplicationRepository;
+    }
+
+    public MatchRequestResponseDto apply(Long requestTeamId, Long waitingId,
+        MatchRequestRequestDto requestDto) {
+
+        Match waiting = matchQueryService.findById(waitingId);
+
+        waiting.validateNotApplyingToOwnTeam(requestTeamId);
+        matchApplicationQueryService.checkDuplicate(waitingId, requestTeamId);
+
+        MatchApplication matchApplication = new MatchApplication(waitingId, requestTeamId, requestDto.lineupId(),
+            requestDto.requestMessage());
+        MatchApplication saved = matchApplicationRepository.save(matchApplication);
+
+        return MatchRequestResponseDto.from(saved, waiting);
+    }
+
+    public void rejectAllPending(Long matchId, Long processorTeamId) {
+        List<MatchApplication> pendingList = matchApplicationRepository.findAllByMatchIdAndStatus(
+            matchId, MatchApplicationStatus.PENDING);
+
+        for (MatchApplication pending : pendingList) {
+            pending.reject(processorTeamId);
+        }
+    }
+}

--- a/src/main/java/com/shootdoori/match/coordination/service/MatchApplicationCommandService.java
+++ b/src/main/java/com/shootdoori/match/coordination/service/MatchApplicationCommandService.java
@@ -58,6 +58,17 @@ public class MatchApplicationCommandService {
         return MatchRequestResponseDto.from(application, waiting);
     }
 
+    public MatchRequestResponseDto cancel(Long loginUserId, Long requestId) {
+        Long loginTeamId = teamMemberQueryService.getTeamIdByUserId(loginUserId);
+        MatchApplication application = matchApplicationQueryService.findByIdForEntity(requestId);
+
+        application.cancel(loginTeamId);
+
+        Match waiting = matchQueryService.findById(application.getMatchId());
+
+        return MatchRequestResponseDto.from(application, waiting);
+    }
+
     public void rejectAllPending(Long matchId, Long processorTeamId) {
         List<MatchApplication> pendingList = matchApplicationRepository.findAllByMatchIdAndStatus(
             matchId, MatchApplicationStatus.PENDING);

--- a/src/main/java/com/shootdoori/match/coordination/service/MatchApplicationCommandService.java
+++ b/src/main/java/com/shootdoori/match/coordination/service/MatchApplicationCommandService.java
@@ -4,14 +4,9 @@ import com.shootdoori.match.coordination.domain.Match;
 import com.shootdoori.match.coordination.domain.MatchApplication;
 import com.shootdoori.match.coordination.domain.MatchApplicationStatus;
 import com.shootdoori.match.coordination.repository.MatchApplicationRepository;
-import com.shootdoori.match.dto.MatchConfirmedResponseDto;
 import com.shootdoori.match.dto.MatchRequestRequestDto;
 import com.shootdoori.match.dto.MatchRequestResponseDto;
-import com.shootdoori.match.exception.common.DuplicatedException;
-import com.shootdoori.match.exception.common.ErrorCode;
-import com.shootdoori.match.exception.common.NoPermissionException;
-import com.shootdoori.match.exception.common.NotFoundException;
-import java.time.LocalDateTime;
+import com.shootdoori.match.team.service.TeamMemberQueryService;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,23 +15,25 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class MatchApplicationCommandService {
 
+    private final TeamMemberQueryService teamMemberQueryService;
     private final MatchQueryService matchQueryService;
     private final MatchApplicationQueryService matchApplicationQueryService;
     private final MatchApplicationRepository matchApplicationRepository;
 
     public MatchApplicationCommandService(
-        MatchQueryService matchQueryService,
+        TeamMemberQueryService teamMemberQueryService, MatchQueryService matchQueryService,
         MatchApplicationQueryService matchApplicationQueryService,
         MatchApplicationRepository matchApplicationRepository
     ) {
+        this.teamMemberQueryService = teamMemberQueryService;
         this.matchQueryService = matchQueryService;
         this.matchApplicationQueryService = matchApplicationQueryService;
         this.matchApplicationRepository = matchApplicationRepository;
     }
 
-    public MatchRequestResponseDto apply(Long requestTeamId, Long waitingId,
+    public MatchRequestResponseDto apply(Long loginUserId, Long waitingId,
         MatchRequestRequestDto requestDto) {
-
+        Long requestTeamId = teamMemberQueryService.getTeamIdByUserId(loginUserId);
         Match waiting = matchQueryService.findById(waitingId);
 
         waiting.validateNotApplyingToOwnTeam(requestTeamId);
@@ -47,6 +44,18 @@ public class MatchApplicationCommandService {
         MatchApplication saved = matchApplicationRepository.save(matchApplication);
 
         return MatchRequestResponseDto.from(saved, waiting);
+    }
+
+    public MatchRequestResponseDto reject(Long loginUserId, Long requestId) {
+        Long loginTeamId = teamMemberQueryService.getTeamIdByUserId(loginUserId);
+        MatchApplication application = matchApplicationQueryService.findByIdForEntity(requestId);
+
+        Match waiting = matchQueryService.findById(application.getMatchId());
+        waiting.validateHomeTeam(loginTeamId);
+
+        application.reject(loginTeamId);
+
+        return MatchRequestResponseDto.from(application, waiting);
     }
 
     public void rejectAllPending(Long matchId, Long processorTeamId) {

--- a/src/main/java/com/shootdoori/match/coordination/service/MatchApplicationCommandService.java
+++ b/src/main/java/com/shootdoori/match/coordination/service/MatchApplicationCommandService.java
@@ -5,8 +5,8 @@ import com.shootdoori.match.coordination.domain.MatchApplication;
 import com.shootdoori.match.coordination.domain.MatchApplicationStatus;
 import com.shootdoori.match.coordination.repository.MatchApplicationRepository;
 import com.shootdoori.match.dto.MatchConfirmedResponseDto;
-import com.shootdoori.match.dto.MatchRequestRequestDto;
-import com.shootdoori.match.dto.MatchRequestResponseDto;
+import com.shootdoori.match.dto.MatchApplicationRequestDto;
+import com.shootdoori.match.dto.MatchApplicationResponseDto;
 import com.shootdoori.match.team.service.TeamMemberQueryService;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -33,8 +33,8 @@ public class MatchApplicationCommandService {
         this.matchApplicationRepository = matchApplicationRepository;
     }
 
-    public MatchRequestResponseDto apply(Long loginUserId, Long waitingId,
-        MatchRequestRequestDto requestDto) {
+    public MatchApplicationResponseDto apply(Long loginUserId, Long waitingId,
+        MatchApplicationRequestDto requestDto) {
         Long requestTeamId = teamMemberQueryService.getTeamIdByUserId(loginUserId);
         Match waiting = matchQueryService.findById(waitingId);
 
@@ -45,7 +45,7 @@ public class MatchApplicationCommandService {
             requestDto.requestMessage());
         MatchApplication saved = matchApplicationRepository.save(matchApplication);
 
-        return MatchRequestResponseDto.from(saved, waiting);
+        return MatchApplicationResponseDto.from(saved, waiting);
     }
 
     public MatchConfirmedResponseDto accept(Long loginUserId, Long requestId) {
@@ -65,7 +65,7 @@ public class MatchApplicationCommandService {
         return MatchConfirmedResponseDto.from(waiting);
     }
 
-    public MatchRequestResponseDto reject(Long loginUserId, Long requestId) {
+    public MatchApplicationResponseDto reject(Long loginUserId, Long requestId) {
         Long loginTeamId = teamMemberQueryService.getTeamIdByUserId(loginUserId);
         MatchApplication application = matchApplicationQueryService.findByIdForEntity(requestId);
 
@@ -74,10 +74,10 @@ public class MatchApplicationCommandService {
 
         application.reject(loginTeamId);
 
-        return MatchRequestResponseDto.from(application, waiting);
+        return MatchApplicationResponseDto.from(application, waiting);
     }
 
-    public MatchRequestResponseDto cancel(Long loginUserId, Long requestId) {
+    public MatchApplicationResponseDto cancel(Long loginUserId, Long requestId) {
         Long loginTeamId = teamMemberQueryService.getTeamIdByUserId(loginUserId);
         MatchApplication application = matchApplicationQueryService.findByIdForEntity(requestId);
 
@@ -85,7 +85,7 @@ public class MatchApplicationCommandService {
 
         Match waiting = matchQueryService.findById(application.getMatchId());
 
-        return MatchRequestResponseDto.from(application, waiting);
+        return MatchApplicationResponseDto.from(application, waiting);
     }
 
     public void rejectAllPending(Long matchId, Long processorTeamId) {

--- a/src/main/java/com/shootdoori/match/coordination/service/MatchApplicationQueryService.java
+++ b/src/main/java/com/shootdoori/match/coordination/service/MatchApplicationQueryService.java
@@ -1,0 +1,31 @@
+package com.shootdoori.match.coordination.service;
+
+import com.shootdoori.match.coordination.domain.MatchApplication;
+import com.shootdoori.match.coordination.domain.MatchApplicationStatus;
+import com.shootdoori.match.coordination.repository.MatchApplicationRepository;
+import com.shootdoori.match.exception.common.DuplicatedException;
+import com.shootdoori.match.exception.common.ErrorCode;
+import com.shootdoori.match.exception.common.NotFoundException;
+
+public class MatchApplicationQueryService {
+
+    private final MatchApplicationRepository matchApplicationRepository;
+
+    public MatchApplicationQueryService(MatchApplicationRepository matchApplicationRepository) {
+        this.matchApplicationRepository = matchApplicationRepository;
+    }
+
+    public MatchApplication findByIdForEntity(Long id) {
+        MatchApplication application = matchApplicationRepository.findById(id)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.MATCH_REQUEST_NOT_FOUND));
+
+        return application;
+    }
+
+    public void checkDuplicate(Long waitingId, Long requestTeamId) {
+        if (matchApplicationRepository.existsByMatchIdAndRequestTeamIdAndStatus(waitingId,
+            requestTeamId, MatchApplicationStatus.PENDING)) {
+            throw new DuplicatedException(ErrorCode.ALREADY_MATCH_REQUEST);
+        }
+    }
+}

--- a/src/main/java/com/shootdoori/match/dto/MatchApplicationRequestDto.java
+++ b/src/main/java/com/shootdoori/match/dto/MatchApplicationRequestDto.java
@@ -1,6 +1,6 @@
 package com.shootdoori.match.dto;
 
-public record MatchRequestRequestDto(
+public record MatchApplicationRequestDto(
     String requestMessage,
     Long lineupId
 ) {

--- a/src/main/java/com/shootdoori/match/dto/MatchApplicationResponseDto.java
+++ b/src/main/java/com/shootdoori/match/dto/MatchApplicationResponseDto.java
@@ -3,7 +3,7 @@ package com.shootdoori.match.dto;
 import com.shootdoori.match.coordination.domain.Match;
 import com.shootdoori.match.coordination.domain.MatchApplication;
 
-public record MatchRequestResponseDto(
+public record MatchApplicationResponseDto(
     Long requestId,
     Long requestTeamId,
     Long targetTeamId,
@@ -11,8 +11,8 @@ public record MatchRequestResponseDto(
     Long requestTeamLineupId
 ) {
 
-    public static MatchRequestResponseDto from(MatchApplication matchApplication, Match match) {
-        return new MatchRequestResponseDto(
+    public static MatchApplicationResponseDto from(MatchApplication matchApplication, Match match) {
+        return new MatchApplicationResponseDto(
             matchApplication.getId(),
             matchApplication.getRequestTeamId(),
             match.getHomeTeamId(),

--- a/src/main/java/com/shootdoori/match/dto/MatchConfirmedResponseDto.java
+++ b/src/main/java/com/shootdoori/match/dto/MatchConfirmedResponseDto.java
@@ -1,5 +1,6 @@
 package com.shootdoori.match.dto;
 
+import com.shootdoori.match.coordination.domain.Match;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
@@ -13,4 +14,16 @@ public record MatchConfirmedResponseDto(
     Long lineup1Id,
     Long lineup2Id
 ) {
+    public static MatchConfirmedResponseDto from(Match match) {
+        return new MatchConfirmedResponseDto(
+            match.getId(),
+            match.getHomeTeamId(),
+            match.getAwayTeamId(),
+            match.getPreferredDate(),
+            match.getPreferredTimeStart(),
+            match.getVenueId(),
+            match.getHomeLineupId(),
+            match.getAwayLineupId()
+        );
+    }
 }

--- a/src/main/java/com/shootdoori/match/dto/MatchRequestResponseDto.java
+++ b/src/main/java/com/shootdoori/match/dto/MatchRequestResponseDto.java
@@ -1,5 +1,8 @@
 package com.shootdoori.match.dto;
 
+import com.shootdoori.match.coordination.domain.Match;
+import com.shootdoori.match.coordination.domain.MatchApplication;
+
 public record MatchRequestResponseDto(
     Long requestId,
     Long requestTeamId,
@@ -7,4 +10,14 @@ public record MatchRequestResponseDto(
     String requestMessage,
     Long requestTeamLineupId
 ) {
+
+    public static MatchRequestResponseDto from(MatchApplication matchApplication, Match match) {
+        return new MatchRequestResponseDto(
+            matchApplication.getId(),
+            matchApplication.getRequestTeamId(),
+            match.getHomeTeamId(),
+            matchApplication.getRequestMessage(),
+            matchApplication.getLineupId()
+        );
+    }
 }

--- a/src/test/java/com/shootdoori/match/coordination/service/MatchApplicationCommandServiceTest.java
+++ b/src/test/java/com/shootdoori/match/coordination/service/MatchApplicationCommandServiceTest.java
@@ -12,12 +12,15 @@ import com.shootdoori.match.coordination.domain.Match;
 import com.shootdoori.match.coordination.domain.MatchApplication;
 import com.shootdoori.match.coordination.domain.MatchApplicationStatus;
 import com.shootdoori.match.coordination.repository.MatchApplicationRepository;
+import com.shootdoori.match.dto.MatchConfirmedResponseDto;
 import com.shootdoori.match.dto.MatchRequestRequestDto;
 import com.shootdoori.match.dto.MatchRequestResponseDto;
 import com.shootdoori.match.exception.common.DuplicatedException;
 import com.shootdoori.match.exception.common.ErrorCode;
 import com.shootdoori.match.exception.common.NoPermissionException;
 import com.shootdoori.match.team.service.TeamMemberQueryService;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -25,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class MatchApplicationCommandServiceTest {
@@ -72,8 +76,8 @@ class MatchApplicationCommandServiceTest {
         given(waiting.getHomeTeamId()).willReturn(999L);
 
         // when
-        MatchRequestResponseDto response = matchApplicationCommandService.apply(
-            loginUserId, waitingId, dto);
+        MatchRequestResponseDto response = matchApplicationCommandService.apply(loginUserId,
+            waitingId, dto);
 
         // then
         assertThat(response.requestId()).isEqualTo(1L);
@@ -96,8 +100,7 @@ class MatchApplicationCommandServiceTest {
             .when(waiting).validateNotApplyingToOwnTeam(requestTeamId);
 
         // when & then
-        assertThatThrownBy(() ->
-            matchApplicationCommandService.apply(loginUserId, waitingId, dto))
+        assertThatThrownBy(() -> matchApplicationCommandService.apply(loginUserId, waitingId, dto))
             .isInstanceOf(IllegalStateException.class);
     }
 
@@ -116,9 +119,76 @@ class MatchApplicationCommandServiceTest {
             .when(matchApplicationQueryService).checkDuplicate(waitingId, requestTeamId);
 
         // when & then
-        assertThatThrownBy(() ->
-            matchApplicationCommandService.apply(loginUserId, waitingId, dto))
+        assertThatThrownBy(() -> matchApplicationCommandService.apply(loginUserId, waitingId, dto))
             .isInstanceOf(DuplicatedException.class);
+    }
+
+    @Test
+    @DisplayName("매치 신청 수락 성공 시 확정 정보가 반환되고 나머지 pending 신청은 거절된다")
+    void accept_success() {
+        // given
+        Long loginUserId = 1L;
+        Long loginTeamId = 10L;
+        Long requestId = 100L;
+        Long waitingId = 20L;
+
+        MatchApplication accepted = new MatchApplication(waitingId, 30L, 7L, "요청");
+        ReflectionTestUtils.setField(accepted, "id", requestId);
+
+        Match realWaiting = new Match(
+            loginTeamId,
+            LocalDate.of(2026, 3, 20),
+            LocalTime.of(14, 0),
+            LocalTime.of(16, 0),
+            5L,
+            true,
+            "매치 요청",
+            11L
+        );
+        ReflectionTestUtils.setField(realWaiting, "id", waitingId);
+
+        MatchApplication pending1 = mock(MatchApplication.class);
+        MatchApplication pending2 = mock(MatchApplication.class);
+
+        given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(loginTeamId);
+        given(matchApplicationQueryService.findByIdForEntity(requestId)).willReturn(accepted);
+        given(matchQueryService.findById(waitingId)).willReturn(realWaiting);
+        given(matchApplicationRepository.findAllByMatchIdAndStatus(waitingId,
+            MatchApplicationStatus.PENDING)).willReturn(List.of(pending1, pending2));
+
+        // when
+        MatchConfirmedResponseDto response = matchApplicationCommandService.accept(loginUserId,
+            requestId);
+
+        // then
+        verify(pending1).reject(loginTeamId);
+        verify(pending2).reject(loginTeamId);
+        assertThat(response.matchId()).isEqualTo(waitingId);
+        assertThat(response.team1Id()).isEqualTo(loginTeamId);
+        assertThat(response.team2Id()).isEqualTo(accepted.getRequestTeamId());
+        assertThat(response.lineup2Id()).isEqualTo(accepted.getLineupId());
+    }
+
+    @Test
+    @DisplayName("홈팀이 아니면 매치 신청 수락 시 권한 예외가 발생한다")
+    void accept_fail_when_not_home_team() {
+        // given
+        Long loginUserId = 1L;
+        Long loginTeamId = 10L;
+        Long requestId = 100L;
+        Long waitingId = 20L;
+
+        MatchApplication accepted = mock(MatchApplication.class);
+        given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(loginTeamId);
+        given(matchApplicationQueryService.findByIdForEntity(requestId)).willReturn(accepted);
+        given(accepted.getMatchId()).willReturn(waitingId);
+        given(matchQueryService.findById(waitingId)).willReturn(waiting);
+        doThrow(new NoPermissionException(ErrorCode.MATCH_OPERATION_PERMISSION_DENIED))
+            .when(waiting).validateHomeTeam(loginTeamId);
+
+        // when & then
+        assertThatThrownBy(() -> matchApplicationCommandService.accept(loginUserId, requestId))
+            .isInstanceOf(NoPermissionException.class);
     }
 
     @Test
@@ -142,7 +212,8 @@ class MatchApplicationCommandServiceTest {
         given(waiting.getHomeTeamId()).willReturn(loginTeamId);
 
         // when & then
-        MatchRequestResponseDto response = matchApplicationCommandService.reject(loginUserId, requestId);
+        MatchRequestResponseDto response = matchApplicationCommandService.reject(loginUserId,
+            requestId);
         verify(waiting).validateHomeTeam(loginTeamId);
         verify(application).reject(loginTeamId);
         assertThat(response.requestId()).isEqualTo(requestId);
@@ -171,7 +242,7 @@ class MatchApplicationCommandServiceTest {
     }
 
     @Test
-    @DisplayName("매치 신청 취소 성공 시 취소 처리 후 정상적으로 응답을 반환한다")
+    @DisplayName("매치 신청 취소 성공 시 취소 처리 후 응답 DTO를 반환한다")
     void cancel_success() {
         // given
         Long loginUserId = 1L;
@@ -191,7 +262,8 @@ class MatchApplicationCommandServiceTest {
         given(waiting.getHomeTeamId()).willReturn(30L);
 
         // when & then
-        MatchRequestResponseDto response = matchApplicationCommandService.cancel(loginUserId, requestId);
+        MatchRequestResponseDto response = matchApplicationCommandService.cancel(loginUserId,
+            requestId);
         verify(application).cancel(loginTeamId);
         assertThat(response.requestId()).isEqualTo(requestId);
     }

--- a/src/test/java/com/shootdoori/match/coordination/service/MatchApplicationCommandServiceTest.java
+++ b/src/test/java/com/shootdoori/match/coordination/service/MatchApplicationCommandServiceTest.java
@@ -143,11 +143,13 @@ class MatchApplicationCommandServiceTest {
 
         // when & then
         MatchRequestResponseDto response = matchApplicationCommandService.reject(loginUserId, requestId);
+        verify(waiting).validateHomeTeam(loginTeamId);
+        verify(application).reject(loginTeamId);
         assertThat(response.requestId()).isEqualTo(requestId);
     }
 
     @Test
-    @DisplayName("홈팀(매치 생성한 팀)이 아니면 매치 신청 거절 시 권한 예외가 발생한다")
+    @DisplayName("홈팀이 아니면 매치 신청 거절 시 권한 예외가 발생한다")
     void reject_fail_when_not_home_team() {
         // given
         Long loginUserId = 1L;
@@ -165,6 +167,51 @@ class MatchApplicationCommandServiceTest {
 
         // when & then
         assertThatThrownBy(() -> matchApplicationCommandService.reject(loginUserId, requestId))
+            .isInstanceOf(NoPermissionException.class);
+    }
+
+    @Test
+    @DisplayName("매치 신청 취소 성공 시 취소 처리 후 정상적으로 응답을 반환한다")
+    void cancel_success() {
+        // given
+        Long loginUserId = 1L;
+        Long loginTeamId = 10L;
+        Long requestId = 100L;
+        Long waitingId = 20L;
+
+        MatchApplication application = mock(MatchApplication.class);
+        given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(loginTeamId);
+        given(matchApplicationQueryService.findByIdForEntity(requestId)).willReturn(application);
+        given(application.getMatchId()).willReturn(waitingId);
+        given(matchQueryService.findById(waitingId)).willReturn(waiting);
+        given(application.getId()).willReturn(requestId);
+        given(application.getRequestTeamId()).willReturn(loginTeamId);
+        given(application.getRequestMessage()).willReturn("요청");
+        given(application.getLineupId()).willReturn(7L);
+        given(waiting.getHomeTeamId()).willReturn(30L);
+
+        // when & then
+        MatchRequestResponseDto response = matchApplicationCommandService.cancel(loginUserId, requestId);
+        verify(application).cancel(loginTeamId);
+        assertThat(response.requestId()).isEqualTo(requestId);
+    }
+
+    @Test
+    @DisplayName("요청 팀이 아니면 매치 신청 취소 시 권한 예외가 발생한다")
+    void cancel_fail_when_not_request_team() {
+        // given
+        Long loginUserId = 1L;
+        Long loginTeamId = 10L;
+        Long requestId = 100L;
+
+        MatchApplication application = mock(MatchApplication.class);
+        given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(loginTeamId);
+        given(matchApplicationQueryService.findByIdForEntity(requestId)).willReturn(application);
+        doThrow(new NoPermissionException(ErrorCode.MATCH_REQUEST_OWNERSHIP_VIOLATION))
+            .when(application).cancel(loginTeamId);
+
+        // when & then
+        assertThatThrownBy(() -> matchApplicationCommandService.cancel(loginUserId, requestId))
             .isInstanceOf(NoPermissionException.class);
     }
 

--- a/src/test/java/com/shootdoori/match/coordination/service/MatchApplicationCommandServiceTest.java
+++ b/src/test/java/com/shootdoori/match/coordination/service/MatchApplicationCommandServiceTest.java
@@ -16,6 +16,7 @@ import com.shootdoori.match.dto.MatchRequestRequestDto;
 import com.shootdoori.match.dto.MatchRequestResponseDto;
 import com.shootdoori.match.exception.common.DuplicatedException;
 import com.shootdoori.match.exception.common.ErrorCode;
+import com.shootdoori.match.exception.common.NoPermissionException;
 import com.shootdoori.match.team.service.TeamMemberQueryService;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -118,6 +119,53 @@ class MatchApplicationCommandServiceTest {
         assertThatThrownBy(() ->
             matchApplicationCommandService.apply(loginUserId, waitingId, dto))
             .isInstanceOf(DuplicatedException.class);
+    }
+
+    @Test
+    @DisplayName("매치 신청 거절 성공 시 거절 처리 후 응답 DTO를 반환한다")
+    void reject_success() {
+        // given
+        Long loginUserId = 1L;
+        Long loginTeamId = 10L;
+        Long requestId = 100L;
+        Long waitingId = 20L;
+
+        MatchApplication application = mock(MatchApplication.class);
+        given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(loginTeamId);
+        given(matchApplicationQueryService.findByIdForEntity(requestId)).willReturn(application);
+        given(application.getMatchId()).willReturn(waitingId);
+        given(matchQueryService.findById(waitingId)).willReturn(waiting);
+        given(application.getId()).willReturn(requestId);
+        given(application.getRequestTeamId()).willReturn(30L);
+        given(application.getRequestMessage()).willReturn("요청");
+        given(application.getLineupId()).willReturn(7L);
+        given(waiting.getHomeTeamId()).willReturn(loginTeamId);
+
+        // when & then
+        MatchRequestResponseDto response = matchApplicationCommandService.reject(loginUserId, requestId);
+        assertThat(response.requestId()).isEqualTo(requestId);
+    }
+
+    @Test
+    @DisplayName("홈팀(매치 생성한 팀)이 아니면 매치 신청 거절 시 권한 예외가 발생한다")
+    void reject_fail_when_not_home_team() {
+        // given
+        Long loginUserId = 1L;
+        Long loginTeamId = 10L;
+        Long requestId = 100L;
+        Long waitingId = 20L;
+
+        MatchApplication application = mock(MatchApplication.class);
+        given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(loginTeamId);
+        given(matchApplicationQueryService.findByIdForEntity(requestId)).willReturn(application);
+        given(application.getMatchId()).willReturn(waitingId);
+        given(matchQueryService.findById(waitingId)).willReturn(waiting);
+        doThrow(new NoPermissionException(ErrorCode.MATCH_OPERATION_PERMISSION_DENIED))
+            .when(waiting).validateHomeTeam(loginTeamId);
+
+        // when & then
+        assertThatThrownBy(() -> matchApplicationCommandService.reject(loginUserId, requestId))
+            .isInstanceOf(NoPermissionException.class);
     }
 
     @Test

--- a/src/test/java/com/shootdoori/match/coordination/service/MatchApplicationCommandServiceTest.java
+++ b/src/test/java/com/shootdoori/match/coordination/service/MatchApplicationCommandServiceTest.java
@@ -16,6 +16,7 @@ import com.shootdoori.match.dto.MatchRequestRequestDto;
 import com.shootdoori.match.dto.MatchRequestResponseDto;
 import com.shootdoori.match.exception.common.DuplicatedException;
 import com.shootdoori.match.exception.common.ErrorCode;
+import com.shootdoori.match.team.service.TeamMemberQueryService;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -27,6 +28,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class MatchApplicationCommandServiceTest {
 
+    @Mock
+    private TeamMemberQueryService teamMemberQueryService;
     @Mock
     private MatchQueryService matchQueryService;
     @Mock
@@ -41,6 +44,7 @@ class MatchApplicationCommandServiceTest {
     @BeforeEach
     void setUp() {
         matchApplicationCommandService = new MatchApplicationCommandService(
+            teamMemberQueryService,
             matchQueryService,
             matchApplicationQueryService,
             matchApplicationRepository

--- a/src/test/java/com/shootdoori/match/coordination/service/MatchApplicationCommandServiceTest.java
+++ b/src/test/java/com/shootdoori/match/coordination/service/MatchApplicationCommandServiceTest.java
@@ -12,9 +12,9 @@ import com.shootdoori.match.coordination.domain.Match;
 import com.shootdoori.match.coordination.domain.MatchApplication;
 import com.shootdoori.match.coordination.domain.MatchApplicationStatus;
 import com.shootdoori.match.coordination.repository.MatchApplicationRepository;
+import com.shootdoori.match.dto.MatchApplicationRequestDto;
+import com.shootdoori.match.dto.MatchApplicationResponseDto;
 import com.shootdoori.match.dto.MatchConfirmedResponseDto;
-import com.shootdoori.match.dto.MatchRequestRequestDto;
-import com.shootdoori.match.dto.MatchRequestResponseDto;
 import com.shootdoori.match.exception.common.DuplicatedException;
 import com.shootdoori.match.exception.common.ErrorCode;
 import com.shootdoori.match.exception.common.NoPermissionException;
@@ -63,7 +63,7 @@ class MatchApplicationCommandServiceTest {
         Long loginUserId = 1L;
         Long requestTeamId = 10L;
         Long waitingId = 20L;
-        MatchRequestRequestDto dto = new MatchRequestRequestDto("요청", 30L);
+        MatchApplicationRequestDto dto = new MatchApplicationRequestDto("요청", 30L);
 
         MatchApplication saved = mock(MatchApplication.class);
         given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(requestTeamId);
@@ -76,8 +76,7 @@ class MatchApplicationCommandServiceTest {
         given(waiting.getHomeTeamId()).willReturn(999L);
 
         // when
-        MatchRequestResponseDto response = matchApplicationCommandService.apply(loginUserId,
-            waitingId, dto);
+        MatchApplicationResponseDto response = matchApplicationCommandService.apply(loginUserId, waitingId, dto);
 
         // then
         assertThat(response.requestId()).isEqualTo(1L);
@@ -92,7 +91,7 @@ class MatchApplicationCommandServiceTest {
         Long loginUserId = 1L;
         Long requestTeamId = 10L;
         Long waitingId = 20L;
-        MatchRequestRequestDto dto = new MatchRequestRequestDto("요청", 30L);
+        MatchApplicationRequestDto dto = new MatchApplicationRequestDto("요청", 30L);
 
         given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(requestTeamId);
         given(matchQueryService.findById(waitingId)).willReturn(waiting);
@@ -111,7 +110,7 @@ class MatchApplicationCommandServiceTest {
         Long loginUserId = 1L;
         Long requestTeamId = 10L;
         Long waitingId = 20L;
-        MatchRequestRequestDto dto = new MatchRequestRequestDto("요청", 30L);
+        MatchApplicationRequestDto dto = new MatchApplicationRequestDto("요청", 30L);
 
         given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(requestTeamId);
         given(matchQueryService.findById(waitingId)).willReturn(waiting);
@@ -157,8 +156,7 @@ class MatchApplicationCommandServiceTest {
             MatchApplicationStatus.PENDING)).willReturn(List.of(pending1, pending2));
 
         // when
-        MatchConfirmedResponseDto response = matchApplicationCommandService.accept(loginUserId,
-            requestId);
+        MatchConfirmedResponseDto response = matchApplicationCommandService.accept(loginUserId, requestId);
 
         // then
         verify(pending1).reject(loginTeamId);
@@ -212,8 +210,7 @@ class MatchApplicationCommandServiceTest {
         given(waiting.getHomeTeamId()).willReturn(loginTeamId);
 
         // when & then
-        MatchRequestResponseDto response = matchApplicationCommandService.reject(loginUserId,
-            requestId);
+        MatchApplicationResponseDto response = matchApplicationCommandService.reject(loginUserId, requestId);
         verify(waiting).validateHomeTeam(loginTeamId);
         verify(application).reject(loginTeamId);
         assertThat(response.requestId()).isEqualTo(requestId);
@@ -262,8 +259,7 @@ class MatchApplicationCommandServiceTest {
         given(waiting.getHomeTeamId()).willReturn(30L);
 
         // when & then
-        MatchRequestResponseDto response = matchApplicationCommandService.cancel(loginUserId,
-            requestId);
+        MatchApplicationResponseDto response = matchApplicationCommandService.cancel(loginUserId, requestId);
         verify(application).cancel(loginTeamId);
         assertThat(response.requestId()).isEqualTo(requestId);
     }

--- a/src/test/java/com/shootdoori/match/coordination/service/MatchApplicationCommandServiceTest.java
+++ b/src/test/java/com/shootdoori/match/coordination/service/MatchApplicationCommandServiceTest.java
@@ -1,0 +1,133 @@
+package com.shootdoori.match.coordination.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.shootdoori.match.coordination.domain.Match;
+import com.shootdoori.match.coordination.domain.MatchApplication;
+import com.shootdoori.match.coordination.domain.MatchApplicationStatus;
+import com.shootdoori.match.coordination.repository.MatchApplicationRepository;
+import com.shootdoori.match.dto.MatchRequestRequestDto;
+import com.shootdoori.match.dto.MatchRequestResponseDto;
+import com.shootdoori.match.exception.common.DuplicatedException;
+import com.shootdoori.match.exception.common.ErrorCode;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MatchApplicationCommandServiceTest {
+
+    @Mock
+    private MatchQueryService matchQueryService;
+    @Mock
+    private MatchApplicationQueryService matchApplicationQueryService;
+    @Mock
+    private MatchApplicationRepository matchApplicationRepository;
+    @Mock
+    private Match waiting;
+
+    private MatchApplicationCommandService matchApplicationCommandService;
+
+    @BeforeEach
+    void setUp() {
+        matchApplicationCommandService = new MatchApplicationCommandService(
+            matchQueryService,
+            matchApplicationQueryService,
+            matchApplicationRepository
+        );
+    }
+
+    @Test
+    @DisplayName("매치 신청 성공 시 요청 정보가 저장되고 응답 DTO가 반환된다")
+    void apply_success() {
+        // given
+        Long requestTeamId = 10L;
+        Long waitingId = 20L;
+        MatchRequestRequestDto dto = new MatchRequestRequestDto("요청", 30L);
+
+        MatchApplication saved = mock(MatchApplication.class);
+        given(matchQueryService.findById(waitingId)).willReturn(waiting);
+        given(matchApplicationRepository.save(any(MatchApplication.class))).willReturn(saved);
+        given(saved.getId()).willReturn(1L);
+        given(saved.getRequestTeamId()).willReturn(requestTeamId);
+        given(saved.getRequestMessage()).willReturn("요청");
+        given(saved.getLineupId()).willReturn(30L);
+        given(waiting.getHomeTeamId()).willReturn(999L);
+
+        // when
+        MatchRequestResponseDto response = matchApplicationCommandService.apply(
+            requestTeamId, waitingId, dto);
+
+        // then
+        assertThat(response.requestId()).isEqualTo(1L);
+        assertThat(response.requestTeamId()).isEqualTo(requestTeamId);
+        assertThat(response.targetTeamId()).isEqualTo(999L);
+    }
+
+    @Test
+    @DisplayName("자기 팀에 신청하면 예외가 발생한다")
+    void apply_fail_when_applying_to_own_team() {
+        // given
+        Long requestTeamId = 10L;
+        Long waitingId = 20L;
+        MatchRequestRequestDto dto = new MatchRequestRequestDto("요청", 30L);
+
+        given(matchQueryService.findById(waitingId)).willReturn(waiting);
+        doThrow(new IllegalStateException("자기 팀에는 매치 신청할 수 없습니다."))
+            .when(waiting).validateNotApplyingToOwnTeam(requestTeamId);
+
+        // when & then
+        assertThatThrownBy(() ->
+            matchApplicationCommandService.apply(requestTeamId, waitingId, dto))
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("중복 신청이면 예외가 발생한다")
+    void apply_fail_when_duplicate() {
+        // given
+        Long requestTeamId = 10L;
+        Long waitingId = 20L;
+        MatchRequestRequestDto dto = new MatchRequestRequestDto("요청", 30L);
+
+        given(matchQueryService.findById(waitingId)).willReturn(waiting);
+        doThrow(new DuplicatedException(ErrorCode.ALREADY_MATCH_REQUEST))
+            .when(matchApplicationQueryService).checkDuplicate(waitingId, requestTeamId);
+
+        // when & then
+        assertThatThrownBy(() ->
+            matchApplicationCommandService.apply(requestTeamId, waitingId, dto))
+            .isInstanceOf(DuplicatedException.class);
+    }
+
+    @Test
+    @DisplayName("모든 PENDING(대기중) 신청을 거절 처리한다")
+    void rejectAllPending_success() {
+        // given
+        Long matchId = 100L;
+        Long processorTeamId = 200L;
+
+        MatchApplication pending1 = mock(MatchApplication.class);
+        MatchApplication pending2 = mock(MatchApplication.class);
+
+        given(matchApplicationRepository.findAllByMatchIdAndStatus(matchId,
+            MatchApplicationStatus.PENDING)).willReturn(List.of(pending1, pending2));
+
+        // when
+        matchApplicationCommandService.rejectAllPending(matchId, processorTeamId);
+
+        // then
+        verify(pending1).reject(processorTeamId);
+        verify(pending2).reject(processorTeamId);
+    }
+}

--- a/src/test/java/com/shootdoori/match/coordination/service/MatchApplicationCommandServiceTest.java
+++ b/src/test/java/com/shootdoori/match/coordination/service/MatchApplicationCommandServiceTest.java
@@ -55,11 +55,13 @@ class MatchApplicationCommandServiceTest {
     @DisplayName("매치 신청 성공 시 요청 정보가 저장되고 응답 DTO가 반환된다")
     void apply_success() {
         // given
+        Long loginUserId = 1L;
         Long requestTeamId = 10L;
         Long waitingId = 20L;
         MatchRequestRequestDto dto = new MatchRequestRequestDto("요청", 30L);
 
         MatchApplication saved = mock(MatchApplication.class);
+        given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(requestTeamId);
         given(matchQueryService.findById(waitingId)).willReturn(waiting);
         given(matchApplicationRepository.save(any(MatchApplication.class))).willReturn(saved);
         given(saved.getId()).willReturn(1L);
@@ -70,7 +72,7 @@ class MatchApplicationCommandServiceTest {
 
         // when
         MatchRequestResponseDto response = matchApplicationCommandService.apply(
-            requestTeamId, waitingId, dto);
+            loginUserId, waitingId, dto);
 
         // then
         assertThat(response.requestId()).isEqualTo(1L);
@@ -82,17 +84,19 @@ class MatchApplicationCommandServiceTest {
     @DisplayName("자기 팀에 신청하면 예외가 발생한다")
     void apply_fail_when_applying_to_own_team() {
         // given
+        Long loginUserId = 1L;
         Long requestTeamId = 10L;
         Long waitingId = 20L;
         MatchRequestRequestDto dto = new MatchRequestRequestDto("요청", 30L);
 
+        given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(requestTeamId);
         given(matchQueryService.findById(waitingId)).willReturn(waiting);
         doThrow(new IllegalStateException("자기 팀에는 매치 신청할 수 없습니다."))
             .when(waiting).validateNotApplyingToOwnTeam(requestTeamId);
 
         // when & then
         assertThatThrownBy(() ->
-            matchApplicationCommandService.apply(requestTeamId, waitingId, dto))
+            matchApplicationCommandService.apply(loginUserId, waitingId, dto))
             .isInstanceOf(IllegalStateException.class);
     }
 
@@ -100,17 +104,19 @@ class MatchApplicationCommandServiceTest {
     @DisplayName("중복 신청이면 예외가 발생한다")
     void apply_fail_when_duplicate() {
         // given
+        Long loginUserId = 1L;
         Long requestTeamId = 10L;
         Long waitingId = 20L;
         MatchRequestRequestDto dto = new MatchRequestRequestDto("요청", 30L);
 
+        given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(requestTeamId);
         given(matchQueryService.findById(waitingId)).willReturn(waiting);
         doThrow(new DuplicatedException(ErrorCode.ALREADY_MATCH_REQUEST))
             .when(matchApplicationQueryService).checkDuplicate(waitingId, requestTeamId);
 
         // when & then
         assertThatThrownBy(() ->
-            matchApplicationCommandService.apply(requestTeamId, waitingId, dto))
+            matchApplicationCommandService.apply(loginUserId, waitingId, dto))
             .isInstanceOf(DuplicatedException.class);
     }
 

--- a/src/test/java/com/shootdoori/match/coordination/service/MatchCommandServiceTest.java
+++ b/src/test/java/com/shootdoori/match/coordination/service/MatchCommandServiceTest.java
@@ -53,6 +53,7 @@ class MatchCommandServiceTest {
     @Test
     @DisplayName("매치 조율을 생성하면 팀 정보를 변환해 저장하고 응답을 반환한다")
     void create_success() {
+        // given
         Long loginUserId = 10L;
         Long homeTeamId = 100L;
         Long venueId = 5L;
@@ -78,8 +79,8 @@ class MatchCommandServiceTest {
         Match saved = mock(Match.class);
         given(matchRepository.save(any(Match.class))).willReturn(saved);
 
+        // when & then
         MatchCreateResponseDto response = matchCommandService.create(loginUserId, requestDto);
-
         assertThat(response.teamId()).isEqualTo(homeTeamId);
         assertThat(response.venueId()).isEqualTo(venueId);
     }
@@ -87,6 +88,7 @@ class MatchCommandServiceTest {
     @Test
     @DisplayName("매치 조율을 취소하면 취소 처리 후 대기 중인 요청을 거절한다")
     void cancel_success() {
+        // given
         Long loginUserId = 10L;
         Long loginTeamId = 100L;
         Long waitingId = 1000L;
@@ -106,8 +108,8 @@ class MatchCommandServiceTest {
         given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(loginTeamId);
         given(matchQueryService.findById(waitingId)).willReturn(waiting);
 
+        // when & then
         MatchWaitingCancelResponseDto response = matchCommandService.cancel(loginUserId, waitingId);
-
         assertThat(response.waitingId()).isEqualTo(waitingId);
         assertThat(response.teamId()).isEqualTo(loginTeamId);
         assertThat(response.expiresAt()).isEqualTo(waiting.getExpiresAt());


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
Closes #38 

---

## 🛠️ 뭘 했는지
### 변경 사항
- 매치 신청 지원/수락/거절/취소 기능 구현

### 테스트
- `MatchApplicationCommandService` 단위 테스트 작성

---

## 📷 스크린샷
❌ 

---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
❌ 

---

*PR 확인 부탁드려요! 🙏*