### PR TITLE
feat: 팀별 라인업 생성/수정/삭제/조회 기능 추가

### DIFF
--- a/src/main/java/com/shootdoori/match/coordination/controller/LineupController.java
+++ b/src/main/java/com/shootdoori/match/coordination/controller/LineupController.java
@@ -2,14 +2,21 @@ package com.shootdoori.match.coordination.controller;
 
 import com.shootdoori.match.coordination.service.LineupCommandService;
 import com.shootdoori.match.coordination.service.LineupQueryService;
+import com.shootdoori.match.dto.LineupCreateRequestDto;
 import com.shootdoori.match.dto.LineupMemberRequestDto;
 import com.shootdoori.match.dto.LineupMemberResponseDto;
 import com.shootdoori.match.resolver.LoginUser;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/lineups")
@@ -26,16 +33,21 @@ public class LineupController {
         this.lineupQueryService = lineupQueryService;
     }
 
-    @PostMapping()
-    public ResponseEntity<List<LineupMemberResponseDto>> create(@RequestBody List<LineupMemberRequestDto> requestDtos,
-                                                                      @LoginUser Long userId) {
-        return new ResponseEntity<>(HttpStatus.CREATED);
+    @PostMapping
+    public ResponseEntity<List<LineupMemberResponseDto>> create(
+        @LoginUser Long loginUserId,
+        @RequestBody LineupCreateRequestDto requestDto
+    ) {
+        return new ResponseEntity<>(
+            lineupCommandService.create(loginUserId, requestDto.matchId(), requestDto.members()),
+            HttpStatus.CREATED
+        );
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<List<LineupMemberResponseDto>> findById(
         @LoginUser Long loginUserId,
-        @PathVariable Long lineupId
+        @PathVariable Long id
     ) {
         return new ResponseEntity<>(
             lineupQueryService.findById(loginUserId, id),
@@ -44,15 +56,23 @@ public class LineupController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<List<LineupMemberResponseDto>> update(@PathVariable Long id,
-                                                                @RequestBody List<LineupMemberRequestDto> requestDtos,
-                                                                @LoginUser Long userId) {
-        return new ResponseEntity<>(HttpStatus.OK);
+    public ResponseEntity<List<LineupMemberResponseDto>> update(
+        @LoginUser Long loginUserId,
+        @PathVariable Long id,
+        @RequestBody List<LineupMemberRequestDto> requestDtos
+    ) {
+        return new ResponseEntity<>(
+            lineupCommandService.update(loginUserId, id, requestDtos),
+            HttpStatus.OK
+        );
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@PathVariable Long id,
-                                             @LoginUser Long userId) {
+    public ResponseEntity<Void> delete(
+        @LoginUser Long loginUserId,
+        @PathVariable Long id
+    ) {
+        lineupCommandService.delete(loginUserId, id);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/shootdoori/match/coordination/controller/LineupController.java
+++ b/src/main/java/com/shootdoori/match/coordination/controller/LineupController.java
@@ -1,5 +1,7 @@
 package com.shootdoori.match.coordination.controller;
 
+import com.shootdoori.match.coordination.service.LineupCommandService;
+import com.shootdoori.match.coordination.service.LineupQueryService;
 import com.shootdoori.match.dto.LineupMemberRequestDto;
 import com.shootdoori.match.dto.LineupMemberResponseDto;
 import com.shootdoori.match.resolver.LoginUser;
@@ -13,6 +15,17 @@ import java.util.List;
 @RequestMapping("/api/lineups")
 public class LineupController {
 
+    private final LineupCommandService lineupCommandService;
+    private final LineupQueryService lineupQueryService;
+
+    public LineupController(
+        LineupCommandService lineupCommandService,
+        LineupQueryService lineupQueryService
+    ) {
+        this.lineupCommandService = lineupCommandService;
+        this.lineupQueryService = lineupQueryService;
+    }
+
     @PostMapping()
     public ResponseEntity<List<LineupMemberResponseDto>> create(@RequestBody List<LineupMemberRequestDto> requestDtos,
                                                                       @LoginUser Long userId) {
@@ -20,8 +33,14 @@ public class LineupController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<List<LineupMemberResponseDto>> findById(@PathVariable Long id) {
-        return new ResponseEntity<>(HttpStatus.OK);
+    public ResponseEntity<List<LineupMemberResponseDto>> findById(
+        @LoginUser Long loginUserId,
+        @PathVariable Long lineupId
+    ) {
+        return new ResponseEntity<>(
+            lineupQueryService.findById(loginUserId, id),
+            HttpStatus.OK
+        );
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/shootdoori/match/coordination/domain/Lineup.java
+++ b/src/main/java/com/shootdoori/match/coordination/domain/Lineup.java
@@ -20,21 +20,20 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "lineup")
 public class Lineup {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
+    
     @Column(name = "match_id", nullable = false)
     private Long matchId;
-
-    @Column(name = "team_id", nullable = false)
+    
+    @Column(name = "team_id", nullable = false) 
     private Long teamId;
-
+    
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true, optional = false)
     @JoinColumn(name = "lineup_members_id", nullable = false, unique = true)
     private LineupMembers members;
-
+    
     @Embedded
     private TimeStamp timeStamp = new TimeStamp();
 
@@ -75,5 +74,7 @@ public class Lineup {
         return matchId;
     }
 
-    public Long getTeamId() { return teamId; }
+    public Long getTeamId() { 
+        return teamId; 
+    }
 }

--- a/src/main/java/com/shootdoori/match/coordination/domain/LineupMember.java
+++ b/src/main/java/com/shootdoori/match/coordination/domain/LineupMember.java
@@ -1,8 +1,11 @@
 package com.shootdoori.match.coordination.domain;
 
 import com.shootdoori.match.entity.common.Position;
+import com.shootdoori.match.entity.common.TimeStamp;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
@@ -12,9 +15,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import java.util.Objects;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "lineup_member")
 public class LineupMember {
 
@@ -36,6 +42,9 @@ public class LineupMember {
     @Column(name = "is_starter", nullable = false)
     private boolean isStarter;
 
+    @Embedded
+    private TimeStamp timeStamp = new TimeStamp();
+
     protected LineupMember() {
     }
 
@@ -53,12 +62,24 @@ public class LineupMember {
         return teamMemberId;
     }
 
+    public Long getId() {
+        return id;
+    }
+
     public Position getPosition() {
         return position;
     }
 
     public boolean isStarter() {
         return isStarter;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return timeStamp.getCreatedAt();
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return timeStamp.getUpdatedAt();
     }
 
     public boolean isSameTeamMember(Long teamMemberId) {

--- a/src/main/java/com/shootdoori/match/coordination/repository/LineupRepository.java
+++ b/src/main/java/com/shootdoori/match/coordination/repository/LineupRepository.java
@@ -1,0 +1,10 @@
+package com.shootdoori.match.coordination.repository;
+
+import com.shootdoori.match.coordination.domain.Lineup;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LineupRepository extends JpaRepository<Lineup, Long> {
+
+    Optional<Lineup> findByIdAndTeamId(Long lineupId, Long teamId);
+}

--- a/src/main/java/com/shootdoori/match/coordination/service/LineupCommandService.java
+++ b/src/main/java/com/shootdoori/match/coordination/service/LineupCommandService.java
@@ -50,7 +50,7 @@ public class LineupCommandService {
     public List<LineupMemberResponseDto> update(Long loginUserId, Long lineupId,
         List<LineupMemberRequestDto> requestDtos) {
         Long loginTeamId = teamMemberQueryService.getTeamIdByUserId(loginUserId);
-        Lineup lineup = findOwnedLineup(loginTeamId, lineupId);
+        Lineup lineup = findByIdForEntity(loginTeamId, lineupId);
 
         clearMembers(lineup);
         addMembers(lineup, loginTeamId, requestDtos);
@@ -61,7 +61,7 @@ public class LineupCommandService {
 
     public void delete(Long loginUserId, Long lineupId) {
         Long loginTeamId = teamMemberQueryService.getTeamIdByUserId(loginUserId);
-        Lineup lineup = findOwnedLineup(loginTeamId, lineupId);
+        Lineup lineup = findByIdForEntity(loginTeamId, lineupId);
         lineupRepository.delete(lineup);
     }
 
@@ -93,7 +93,7 @@ public class LineupCommandService {
     }
 
 
-    private Lineup findOwnedLineup(Long teamId, Long lineupId) {
+    private Lineup findByIdForEntity(Long teamId, Long lineupId) {
         return lineupRepository.findByIdAndTeamId(lineupId, teamId)
             .orElseThrow(() -> new NotFoundException(ErrorCode.LINEUP_NOT_FOUND));
     }

--- a/src/main/java/com/shootdoori/match/coordination/service/LineupCommandService.java
+++ b/src/main/java/com/shootdoori/match/coordination/service/LineupCommandService.java
@@ -1,0 +1,102 @@
+package com.shootdoori.match.coordination.service;
+
+import com.shootdoori.match.coordination.domain.Lineup;
+import com.shootdoori.match.coordination.domain.LineupMember;
+import com.shootdoori.match.coordination.repository.LineupRepository;
+import com.shootdoori.match.dto.LineupMemberRequestDto;
+import com.shootdoori.match.dto.LineupMemberResponseDto;
+import com.shootdoori.match.exception.common.CreationFailException;
+import com.shootdoori.match.exception.common.ErrorCode;
+import com.shootdoori.match.exception.common.NotFoundException;
+import com.shootdoori.match.team.domain.TeamMember;
+import com.shootdoori.match.team.service.TeamMemberQueryService;
+import com.shootdoori.match.user.domain.User;
+import com.shootdoori.match.user.service.UserQueryService;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class LineupCommandService {
+
+    private final TeamMemberQueryService teamMemberQueryService;
+    private final LineupQueryService lineupQueryService;
+    private final LineupRepository lineupRepository;
+    private final UserQueryService userQueryService;
+
+    public LineupCommandService(
+        TeamMemberQueryService teamMemberQueryService, LineupQueryService lineupQueryService,
+        LineupRepository lineupRepository, UserQueryService userQueryService
+    ) {
+        this.teamMemberQueryService = teamMemberQueryService;
+        this.lineupQueryService = lineupQueryService;
+        this.lineupRepository = lineupRepository;
+        this.userQueryService = userQueryService;
+    }
+
+    public List<LineupMemberResponseDto> create(Long loginUserId, Long matchId,
+        List<LineupMemberRequestDto> requestDtos) {
+        Long loginTeamId = teamMemberQueryService.getTeamIdByUserId(loginUserId);
+
+        Lineup lineup = new Lineup(matchId, loginTeamId);
+        addMembers(lineup, loginTeamId, requestDtos);
+        validateLineup(lineup);
+
+        Lineup saved = lineupRepository.save(lineup);
+        return LineupMemberResponseDto.fromLineup(saved, teamMemberQueryService, userQueryService);
+    }
+
+    public List<LineupMemberResponseDto> update(Long loginUserId, Long lineupId,
+        List<LineupMemberRequestDto> requestDtos) {
+        Long loginTeamId = teamMemberQueryService.getTeamIdByUserId(loginUserId);
+        Lineup lineup = findOwnedLineup(loginTeamId, lineupId);
+
+        clearMembers(lineup);
+        addMembers(lineup, loginTeamId, requestDtos);
+        validateLineup(lineup);
+
+        return LineupMemberResponseDto.fromLineup(lineup, teamMemberQueryService, userQueryService);
+    }
+
+    public void delete(Long loginUserId, Long lineupId) {
+        Long loginTeamId = teamMemberQueryService.getTeamIdByUserId(loginUserId);
+        Lineup lineup = findOwnedLineup(loginTeamId, lineupId);
+        lineupRepository.delete(lineup);
+    }
+
+    private void addMembers(Lineup lineup, Long loginTeamId, List<LineupMemberRequestDto> requestDtos) {
+        for (LineupMemberRequestDto requestDto : requestDtos) {
+            TeamMember teamMember = teamMemberQueryService.findByIdForEntity(requestDto.teamMemberId());
+            teamMember.validateBelongsToTeam(loginTeamId);
+
+            User user = userQueryService.findByIdForEntity(teamMember.getUserId());
+            lineup.addMember(teamMember.getId(), user.getPosition(), Boolean.TRUE.equals(requestDto.isStarter()));
+        }
+    }
+
+    private void clearMembers(Lineup lineup) {
+        List<Long> memberIds = new ArrayList<>();
+        for (LineupMember member : lineup.getMembers().getMembers()) {
+            memberIds.add(member.getTeamMemberId());
+        }
+
+        for (Long teamMemberId : memberIds) {
+            lineup.removeMember(teamMemberId);
+        }
+    }
+
+    private void validateLineup(Lineup lineup) {
+        if (!lineup.isValidLineup()) {
+            throw new CreationFailException(ErrorCode.LINEUP_CREATION_FAILED);
+        }
+    }
+
+
+    private Lineup findOwnedLineup(Long teamId, Long lineupId) {
+        return lineupRepository.findByIdAndTeamId(lineupId, teamId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.LINEUP_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/shootdoori/match/coordination/service/LineupCommandService.java
+++ b/src/main/java/com/shootdoori/match/coordination/service/LineupCommandService.java
@@ -22,16 +22,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class LineupCommandService {
 
     private final TeamMemberQueryService teamMemberQueryService;
-    private final LineupQueryService lineupQueryService;
     private final LineupRepository lineupRepository;
     private final UserQueryService userQueryService;
 
     public LineupCommandService(
-        TeamMemberQueryService teamMemberQueryService, LineupQueryService lineupQueryService,
-        LineupRepository lineupRepository, UserQueryService userQueryService
+        TeamMemberQueryService teamMemberQueryService,
+        LineupRepository lineupRepository, 
+        UserQueryService userQueryService
     ) {
         this.teamMemberQueryService = teamMemberQueryService;
-        this.lineupQueryService = lineupQueryService;
         this.lineupRepository = lineupRepository;
         this.userQueryService = userQueryService;
     }

--- a/src/main/java/com/shootdoori/match/coordination/service/LineupQueryService.java
+++ b/src/main/java/com/shootdoori/match/coordination/service/LineupQueryService.java
@@ -1,16 +1,12 @@
 package com.shootdoori.match.coordination.service;
 
 import com.shootdoori.match.coordination.domain.Lineup;
-import com.shootdoori.match.coordination.domain.LineupMember;
 import com.shootdoori.match.coordination.repository.LineupRepository;
 import com.shootdoori.match.dto.LineupMemberResponseDto;
 import com.shootdoori.match.exception.common.ErrorCode;
 import com.shootdoori.match.exception.common.NotFoundException;
-import com.shootdoori.match.team.domain.TeamMember;
 import com.shootdoori.match.team.service.TeamMemberQueryService;
-import com.shootdoori.match.user.domain.User;
 import com.shootdoori.match.user.service.UserQueryService;
-import java.util.ArrayList;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/shootdoori/match/coordination/service/LineupQueryService.java
+++ b/src/main/java/com/shootdoori/match/coordination/service/LineupQueryService.java
@@ -1,0 +1,44 @@
+package com.shootdoori.match.coordination.service;
+
+import com.shootdoori.match.coordination.domain.Lineup;
+import com.shootdoori.match.coordination.domain.LineupMember;
+import com.shootdoori.match.coordination.repository.LineupRepository;
+import com.shootdoori.match.dto.LineupMemberResponseDto;
+import com.shootdoori.match.exception.common.ErrorCode;
+import com.shootdoori.match.exception.common.NotFoundException;
+import com.shootdoori.match.team.domain.TeamMember;
+import com.shootdoori.match.team.service.TeamMemberQueryService;
+import com.shootdoori.match.user.domain.User;
+import com.shootdoori.match.user.service.UserQueryService;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class LineupQueryService {
+
+    private final TeamMemberQueryService teamMemberQueryService;
+    private final LineupRepository lineupRepository;
+    private final UserQueryService userQueryService;
+
+    public LineupQueryService(
+        TeamMemberQueryService teamMemberQueryService,
+        LineupRepository lineupRepository,
+        UserQueryService userQueryService
+    ) {
+        this.teamMemberQueryService = teamMemberQueryService;
+        this.lineupRepository = lineupRepository;
+        this.userQueryService = userQueryService;
+    }
+
+    public List<LineupMemberResponseDto> findById(Long loginUserId, Long lineupId) {
+        Long loginTeamId = teamMemberQueryService.getTeamIdByUserId(loginUserId);
+        Lineup lineup = lineupRepository.findByIdAndTeamId(lineupId, loginTeamId)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.LINEUP_NOT_FOUND));
+            
+        return LineupMemberResponseDto.fromLineup(lineup, teamMemberQueryService, userQueryService);
+    }
+    
+}

--- a/src/main/java/com/shootdoori/match/dto/LineupCreateRequestDto.java
+++ b/src/main/java/com/shootdoori/match/dto/LineupCreateRequestDto.java
@@ -1,0 +1,7 @@
+package com.shootdoori.match.dto;
+
+import java.util.List;
+
+public record LineupCreateRequestDto(Long matchId,
+                                     List<LineupMemberRequestDto> members) {
+}

--- a/src/main/java/com/shootdoori/match/dto/LineupMemberResponseDto.java
+++ b/src/main/java/com/shootdoori/match/dto/LineupMemberResponseDto.java
@@ -1,6 +1,14 @@
 package com.shootdoori.match.dto;
 
+import com.shootdoori.match.coordination.domain.Lineup;
+import com.shootdoori.match.coordination.domain.LineupMember;
+import com.shootdoori.match.team.domain.TeamMember;
+import com.shootdoori.match.team.service.TeamMemberQueryService;
+import com.shootdoori.match.user.domain.User;
+import com.shootdoori.match.user.service.UserQueryService;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 public record LineupMemberResponseDto(Long id,
                                       Long lineupId,
@@ -10,4 +18,32 @@ public record LineupMemberResponseDto(Long id,
                                       Boolean isStarter,
                                       LocalDateTime createdAt,
                                       LocalDateTime updatedAt) {
+    
+    public static LineupMemberResponseDto from(LineupMember member, Lineup lineup, User user) {
+        return new LineupMemberResponseDto(
+            member.getId(),
+            lineup.getId(),
+            member.getTeamMemberId(),
+            lineup.getTeamId(),
+            user.getName().value(),
+            member.isStarter(),
+            member.getCreatedAt(),
+            member.getUpdatedAt()
+        );
+    }
+    
+    public static List<LineupMemberResponseDto> fromLineup(Lineup lineup, 
+            TeamMemberQueryService teamMemberQueryService, 
+            UserQueryService userQueryService) {
+        List<LineupMemberResponseDto> responseDtos = new ArrayList<>();
+        
+        for (LineupMember member : lineup.getMembers().getMembers()) {
+            TeamMember teamMember = teamMemberQueryService.findByIdForEntity(member.getTeamMemberId());
+            User user = userQueryService.findByIdForEntity(teamMember.getUserId());
+            
+            responseDtos.add(from(member, lineup, user));
+        }
+        
+        return responseDtos;
+    }
 }

--- a/src/main/java/com/shootdoori/match/team/domain/TeamMember.java
+++ b/src/main/java/com/shootdoori/match/team/domain/TeamMember.java
@@ -15,6 +15,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
+import java.util.Objects;
+
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
@@ -93,6 +95,12 @@ public class TeamMember {
 
     public void validateKickAuthority(TeamMember targetMember) {
         if (!role.canKick(targetMember.getRole())) {
+            throw new NoPermissionException(ErrorCode.NO_PERMISSION);
+        }
+    }
+
+    public void validateBelongsToTeam(Long expectedTeamId) {
+        if (!Objects.equals(this.team.getId(), expectedTeamId)) {
             throw new NoPermissionException(ErrorCode.NO_PERMISSION);
         }
     }

--- a/src/test/java/com/shootdoori/match/coordination/service/LineupCommandServiceTest.java
+++ b/src/test/java/com/shootdoori/match/coordination/service/LineupCommandServiceTest.java
@@ -1,0 +1,203 @@
+package com.shootdoori.match.coordination.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import com.shootdoori.match.coordination.domain.Lineup;
+import com.shootdoori.match.coordination.repository.LineupRepository;
+import com.shootdoori.match.dto.LineupMemberRequestDto;
+import com.shootdoori.match.dto.LineupMemberResponseDto;
+import com.shootdoori.match.entity.common.Position;
+import com.shootdoori.match.exception.common.CreationFailException;
+import com.shootdoori.match.exception.common.NoPermissionException;
+import com.shootdoori.match.exception.common.NotFoundException;
+import com.shootdoori.match.team.domain.TeamMember;
+import com.shootdoori.match.team.service.TeamMemberQueryService;
+import com.shootdoori.match.user.domain.User;
+import com.shootdoori.match.user.service.UserQueryService;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LineupCommandServiceTest {
+
+    @Mock
+    private TeamMemberQueryService teamMemberQueryService;
+    @Mock
+    private LineupRepository lineupRepository;
+    @Mock
+    private UserQueryService userQueryService;
+
+    private LineupCommandService lineupCommandService;
+
+    @BeforeEach
+    void setUp() {
+        lineupCommandService = new LineupCommandService(
+            teamMemberQueryService, lineupRepository, userQueryService
+        );
+    }
+
+    @Test
+    @DisplayName("라인업 생성 성공")
+    void create_success() {
+        // given
+        Long loginUserId = 1L;
+        Long matchId = 10L;
+        Long loginTeamId = 100L;
+        List<LineupMemberRequestDto> requestDtos = createValidLineupRequest();
+        
+        given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(loginTeamId);
+        
+        for (int i = 1; i <= 11; i++) {
+            TeamMember teamMember = mock(TeamMember.class);
+            given(teamMember.getId()).willReturn((long) i);
+            given(teamMember.getUserId()).willReturn((long) i);
+            given(teamMemberQueryService.findByIdForEntity((long) i)).willReturn(teamMember);
+            
+            User user = mock(User.class);
+            given(user.getPosition()).willReturn(Position.AM);
+            given(userQueryService.findByIdForEntity((long) i)).willReturn(user);
+        }
+        
+        given(lineupRepository.save(any(Lineup.class))).willReturn(new Lineup(matchId, loginTeamId));
+
+        // when
+        List<LineupMemberResponseDto> result = lineupCommandService.create(loginUserId, matchId, requestDtos);
+
+        // then
+        assertThat(result).isNotNull();
+        then(lineupRepository).should().save(any(Lineup.class));
+    }
+
+    @Test
+    @DisplayName("라인업 생성 실패 - 타 팀 멤버 포함")
+    void create_fail_notOwnedTeamMember() {
+        // given
+        Long loginUserId = 1L;
+        Long matchId = 10L;
+        Long loginTeamId = 100L;
+        List<LineupMemberRequestDto> requestDtos = List.of(
+            new LineupMemberRequestDto(1L, true)
+        );
+        
+        given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(loginTeamId);
+        
+        TeamMember teamMember = mock(TeamMember.class);
+        given(teamMemberQueryService.findByIdForEntity(1L)).willReturn(teamMember);
+        doThrow(new NoPermissionException()).when(teamMember).validateBelongsToTeam(loginTeamId);
+
+        // when & then
+        assertThatThrownBy(() -> lineupCommandService.create(loginUserId, matchId, requestDtos))
+            .isInstanceOf(NoPermissionException.class);
+    }
+
+    @Test
+    @DisplayName("라인업 수정 실패 - 유효하지 않은 라인업 (1명)")
+    void update_fail_invalidLineup() {
+        // given
+        Long loginUserId = 1L;
+        Long lineupId = 999L;
+        Long loginTeamId = 100L;
+        List<LineupMemberRequestDto> requestDtos = List.of(
+            new LineupMemberRequestDto(1L, true)
+        );
+        
+        given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(loginTeamId);
+        
+        Lineup lineup = new Lineup(10L, loginTeamId);
+        given(lineupRepository.findByIdAndTeamId(lineupId, loginTeamId)).willReturn(Optional.of(lineup));
+        
+        TeamMember teamMember = mock(TeamMember.class);
+        given(teamMember.getId()).willReturn(1L);
+        given(teamMember.getUserId()).willReturn(1L);
+        given(teamMemberQueryService.findByIdForEntity(1L)).willReturn(teamMember);
+        
+        User user = mock(User.class);
+        given(user.getPosition()).willReturn(Position.AM);
+        given(userQueryService.findByIdForEntity(1L)).willReturn(user);
+
+        // when & then
+        assertThatThrownBy(() -> lineupCommandService.update(loginUserId, lineupId, requestDtos))
+            .isInstanceOf(CreationFailException.class);
+    }
+
+    @Test
+    @DisplayName("라인업 수정 실패 - 소유하지 않은 라인업")
+    void update_fail_notFound() {
+        // given
+        Long loginUserId = 1L;
+        Long lineupId = 999L;
+        Long loginTeamId = 100L;
+        List<LineupMemberRequestDto> requestDtos = createValidLineupRequest();
+        
+        given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(loginTeamId);
+        given(lineupRepository.findByIdAndTeamId(lineupId, loginTeamId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> lineupCommandService.update(loginUserId, lineupId, requestDtos))
+            .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("라인업 삭제 성공")
+    void delete_success() {
+        // given
+        Long loginUserId = 1L;
+        Long lineupId = 999L;
+        Long loginTeamId = 100L;
+        
+        given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(loginTeamId);
+        
+        Lineup lineup = new Lineup(10L, loginTeamId);
+        given(lineupRepository.findByIdAndTeamId(lineupId, loginTeamId)).willReturn(Optional.of(lineup));
+
+        // when
+        lineupCommandService.delete(loginUserId, lineupId);
+
+        // then
+        then(lineupRepository).should().delete(lineup);
+    }
+
+    @Test
+    @DisplayName("라인업 삭제 실패 - 소유하지 않은 라인업")
+    void delete_fail_notFound() {
+        // given
+        Long loginUserId = 1L;
+        Long lineupId = 999L;
+        Long loginTeamId = 100L;
+        
+        given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(loginTeamId);
+        given(lineupRepository.findByIdAndTeamId(lineupId, loginTeamId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> lineupCommandService.delete(loginUserId, lineupId))
+            .isInstanceOf(NotFoundException.class);
+    }
+
+    private List<LineupMemberRequestDto> createValidLineupRequest() {
+        return List.of(
+            new LineupMemberRequestDto(1L, true),
+            new LineupMemberRequestDto(2L, true),
+            new LineupMemberRequestDto(3L, true),
+            new LineupMemberRequestDto(4L, true),
+            new LineupMemberRequestDto(5L, true),
+            new LineupMemberRequestDto(6L, true),
+            new LineupMemberRequestDto(7L, true),
+            new LineupMemberRequestDto(8L, true),
+            new LineupMemberRequestDto(9L, true),
+            new LineupMemberRequestDto(10L, true),
+            new LineupMemberRequestDto(11L, true)
+        );
+    }
+}

--- a/src/test/java/com/shootdoori/match/coordination/service/MatchApplicationCommandServiceTest.java
+++ b/src/test/java/com/shootdoori/match/coordination/service/MatchApplicationCommandServiceTest.java
@@ -67,7 +67,7 @@ class MatchApplicationCommandServiceTest {
 
         MatchApplication saved = mock(MatchApplication.class);
         given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(requestTeamId);
-        given(matchQueryService.findById(waitingId)).willReturn(waiting);
+        given(matchQueryService.findWaitingById(waitingId)).willReturn(waiting);
         given(matchApplicationRepository.save(any(MatchApplication.class))).willReturn(saved);
         given(saved.getId()).willReturn(1L);
         given(saved.getRequestTeamId()).willReturn(requestTeamId);
@@ -94,7 +94,7 @@ class MatchApplicationCommandServiceTest {
         MatchApplicationRequestDto dto = new MatchApplicationRequestDto("요청", 30L);
 
         given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(requestTeamId);
-        given(matchQueryService.findById(waitingId)).willReturn(waiting);
+        given(matchQueryService.findWaitingById(waitingId)).willReturn(waiting);
         doThrow(new IllegalStateException("자기 팀에는 매치 신청할 수 없습니다."))
             .when(waiting).validateNotApplyingToOwnTeam(requestTeamId);
 
@@ -113,7 +113,7 @@ class MatchApplicationCommandServiceTest {
         MatchApplicationRequestDto dto = new MatchApplicationRequestDto("요청", 30L);
 
         given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(requestTeamId);
-        given(matchQueryService.findById(waitingId)).willReturn(waiting);
+        given(matchQueryService.findWaitingById(waitingId)).willReturn(waiting);
         doThrow(new DuplicatedException(ErrorCode.ALREADY_MATCH_REQUEST))
             .when(matchApplicationQueryService).checkDuplicate(waitingId, requestTeamId);
 
@@ -151,7 +151,7 @@ class MatchApplicationCommandServiceTest {
 
         given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(loginTeamId);
         given(matchApplicationQueryService.findByIdForEntity(requestId)).willReturn(accepted);
-        given(matchQueryService.findById(waitingId)).willReturn(realWaiting);
+        given(matchQueryService.findWaitingById(waitingId)).willReturn(realWaiting);
         given(matchApplicationRepository.findAllByMatchIdAndStatus(waitingId,
             MatchApplicationStatus.PENDING)).willReturn(List.of(pending1, pending2));
 
@@ -180,7 +180,7 @@ class MatchApplicationCommandServiceTest {
         given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(loginTeamId);
         given(matchApplicationQueryService.findByIdForEntity(requestId)).willReturn(accepted);
         given(accepted.getMatchId()).willReturn(waitingId);
-        given(matchQueryService.findById(waitingId)).willReturn(waiting);
+        given(matchQueryService.findWaitingById(waitingId)).willReturn(waiting);
         doThrow(new NoPermissionException(ErrorCode.MATCH_OPERATION_PERMISSION_DENIED))
             .when(waiting).validateHomeTeam(loginTeamId);
 
@@ -202,7 +202,7 @@ class MatchApplicationCommandServiceTest {
         given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(loginTeamId);
         given(matchApplicationQueryService.findByIdForEntity(requestId)).willReturn(application);
         given(application.getMatchId()).willReturn(waitingId);
-        given(matchQueryService.findById(waitingId)).willReturn(waiting);
+        given(matchQueryService.findWaitingById(waitingId)).willReturn(waiting);
         given(application.getId()).willReturn(requestId);
         given(application.getRequestTeamId()).willReturn(30L);
         given(application.getRequestMessage()).willReturn("요청");
@@ -229,7 +229,7 @@ class MatchApplicationCommandServiceTest {
         given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(loginTeamId);
         given(matchApplicationQueryService.findByIdForEntity(requestId)).willReturn(application);
         given(application.getMatchId()).willReturn(waitingId);
-        given(matchQueryService.findById(waitingId)).willReturn(waiting);
+        given(matchQueryService.findWaitingById(waitingId)).willReturn(waiting);
         doThrow(new NoPermissionException(ErrorCode.MATCH_OPERATION_PERMISSION_DENIED))
             .when(waiting).validateHomeTeam(loginTeamId);
 
@@ -251,7 +251,7 @@ class MatchApplicationCommandServiceTest {
         given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(loginTeamId);
         given(matchApplicationQueryService.findByIdForEntity(requestId)).willReturn(application);
         given(application.getMatchId()).willReturn(waitingId);
-        given(matchQueryService.findById(waitingId)).willReturn(waiting);
+        given(matchQueryService.findWaitingById(waitingId)).willReturn(waiting);
         given(application.getId()).willReturn(requestId);
         given(application.getRequestTeamId()).willReturn(loginTeamId);
         given(application.getRequestMessage()).willReturn("요청");

--- a/src/test/java/com/shootdoori/match/coordination/service/MatchCommandServiceTest.java
+++ b/src/test/java/com/shootdoori/match/coordination/service/MatchCommandServiceTest.java
@@ -106,7 +106,7 @@ class MatchCommandServiceTest {
         ReflectionTestUtils.setField(waiting, "id", waitingId);
 
         given(teamMemberQueryService.getTeamIdByUserId(loginUserId)).willReturn(loginTeamId);
-        given(matchQueryService.findById(waitingId)).willReturn(waiting);
+        given(matchQueryService.findWaitingById(waitingId)).willReturn(waiting);
 
         // when & then
         MatchWaitingCancelResponseDto response = matchCommandService.cancel(loginUserId, waitingId);


### PR DESCRIPTION
# 🔥 Pull Request

## 📌 관련 이슈
- closes #42
- closes #43

---

## 🛠️ 뭘 했는지
### 도메인 & 비즈니스 로직
1. 라인업 엔티티 구조 설계 (Lineup ↔ LineupMembers ↔ LineupMember)
2. 팀 소속 검증 로직 (TeamMember.validateBelongsToTeam())
3. 라인업 규칙 검증 (11-18명, 선발 최대 11명)

### 서비스 레이어
1. LineupCommandService: 생성/수정/삭제 기능
2. LineupQueryService: 조회 기능
3. 권한 검증 (팀 소유자만 접근)

### DTO & 변환
1. LineupCreateRequestDto 래퍼 DTO 생성
2. LineupMemberResponseDto에 정적 팩토리 메서드 추가

### 테스트
1. 단위 테스트 6개 (생성/수정/삭제 성공/실패)

---

## 📷 스크린샷
❌ 

---

## ✅ 확인 사항
- [x] 로컬에서 잘 돌아감
- [x] 기존 기능 안 망가뜨림
- [x] 코드 정리함

---

## 👀 특히 봐주세요!
❌ 

---

*PR 확인 부탁드려요! 🙏*